### PR TITLE
Added intermediate-song payloads for 45 WGS PCAWG donors from the PAC…

### DIFF
--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/001e1e51-d6be-4447-bb05-41124d0af4cc.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/001e1e51-d6be-4447-bb05-41124d0af4cc.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057676",
+            "matchedNormalSubmitterSampleId": "8057677",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057676",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0185",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "1d10be004c59f426f5750e17232a554e.bam",
+            "fileSize": 155467451669,
+            "fileType": "BAM",
+            "fileMd5sum": "1d10be004c59f426f5750e17232a554e",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "001e1e51-d6be-4447-bb05-41124d0af4cc",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "1d10be004c59f426f5750e17232a554e.bam",
+            "file_r2": "1d10be004c59f426f5750e17232a554e.bam",
+            "insert_size": 397,
+            "platform_unit": "QCMG:20130423022105188_8057676",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_T",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130423022105188",
+            "submitter_read_group_id": "QCMG:20130423022105188_8057676"
+        },
+        {
+            "file_r1": "1d10be004c59f426f5750e17232a554e.bam",
+            "file_r2": "1d10be004c59f426f5750e17232a554e.bam",
+            "insert_size": 396,
+            "platform_unit": "QCMG:20130423042105646_8057676",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_T",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130423042105646",
+            "submitter_read_group_id": "QCMG:20130423042105646_8057676"
+        },
+        {
+            "file_r1": "1d10be004c59f426f5750e17232a554e.bam",
+            "file_r2": "1d10be004c59f426f5750e17232a554e.bam",
+            "insert_size": 396,
+            "platform_unit": "QCMG:20130423054936807_8057676",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_T",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130423054936807",
+            "submitter_read_group_id": "QCMG:20130423054936807_8057676"
+        },
+        {
+            "file_r1": "1d10be004c59f426f5750e17232a554e.bam",
+            "file_r2": "1d10be004c59f426f5750e17232a554e.bam",
+            "insert_size": 397,
+            "platform_unit": "QCMG:20130423055125659_8057676",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_T",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130423055125659",
+            "submitter_read_group_id": "QCMG:20130423055125659_8057676"
+        },
+        {
+            "file_r1": "1d10be004c59f426f5750e17232a554e.bam",
+            "file_r2": "1d10be004c59f426f5750e17232a554e.bam",
+            "insert_size": 396,
+            "platform_unit": "QCMG:20130423070036340_8057676",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_T",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130423070036340",
+            "submitter_read_group_id": "QCMG:20130423070036340_8057676"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-99",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/010e6ae7-dbf6-437b-8d3a-47e6f1500afe.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/010e6ae7-dbf6-437b-8d3a-47e6f1500afe.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8035639",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8035639",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0212",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "f7c56d958e51df9dd9fdd6df9bd2826e.bam",
+            "fileSize": 103912856306,
+            "fileType": "BAM",
+            "fileMd5sum": "f7c56d958e51df9dd9fdd6df9bd2826e",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "010e6ae7-dbf6-437b-8d3a-47e6f1500afe",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "f7c56d958e51df9dd9fdd6df9bd2826e.bam",
+            "file_r2": "f7c56d958e51df9dd9fdd6df9bd2826e.bam",
+            "insert_size": 298,
+            "platform_unit": "QCMG:20130217013402697_8035639",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5265A1AR9",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130217013402697",
+            "submitter_read_group_id": "QCMG:20130217013402697_8035639"
+        },
+        {
+            "file_r1": "f7c56d958e51df9dd9fdd6df9bd2826e.bam",
+            "file_r2": "f7c56d958e51df9dd9fdd6df9bd2826e.bam",
+            "insert_size": 302,
+            "platform_unit": "QCMG:20130217102846359_8035639",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5265A1AR9",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130217102846359",
+            "submitter_read_group_id": "QCMG:20130217102846359_8035639"
+        },
+        {
+            "file_r1": "f7c56d958e51df9dd9fdd6df9bd2826e.bam",
+            "file_r2": "f7c56d958e51df9dd9fdd6df9bd2826e.bam",
+            "insert_size": 298,
+            "platform_unit": "QCMG:20130217105905797_8035639",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5265A1AR9",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130217105905797",
+            "submitter_read_group_id": "QCMG:20130217105905797_8035639"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-159",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/06cce10e-b17d-4121-846e-3eab60068863.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/06cce10e-b17d-4121-846e-3eab60068863.json
@@ -1,0 +1,101 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8033530",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8033530",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0087",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "8649cb433bf5990a8fa3c31a43a53fff.bam",
+            "fileSize": 105137537598,
+            "fileType": "BAM",
+            "fileMd5sum": "8649cb433bf5990a8fa3c31a43a53fff",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "06cce10e-b17d-4121-846e-3eab60068863",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "8649cb433bf5990a8fa3c31a43a53fff.bam",
+            "file_r2": "8649cb433bf5990a8fa3c31a43a53fff.bam",
+            "insert_size": 396,
+            "platform_unit": "QCMG:20121212093015399_8033530",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121120_O",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20121212093015399",
+            "submitter_read_group_id": "QCMG:20121212093015399_8033530"
+        },
+        {
+            "file_r1": "8649cb433bf5990a8fa3c31a43a53fff.bam",
+            "file_r2": "8649cb433bf5990a8fa3c31a43a53fff.bam",
+            "insert_size": 398,
+            "platform_unit": "QCMG:20121212101331536_8033530",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121120_P",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20121212101331536",
+            "submitter_read_group_id": "QCMG:20121212101331536_8033530"
+        },
+        {
+            "file_r1": "8649cb433bf5990a8fa3c31a43a53fff.bam",
+            "file_r2": "8649cb433bf5990a8fa3c31a43a53fff.bam",
+            "insert_size": 395,
+            "platform_unit": "QCMG:20130207074859507_8033530",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121120_P",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130207074859507",
+            "submitter_read_group_id": "QCMG:20130207074859507_8033530"
+        },
+        {
+            "file_r1": "8649cb433bf5990a8fa3c31a43a53fff.bam",
+            "file_r2": "8649cb433bf5990a8fa3c31a43a53fff.bam",
+            "insert_size": 395,
+            "platform_unit": "QCMG:20130207085805508_8033530",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121120_O",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130207085805508",
+            "submitter_read_group_id": "QCMG:20130207085805508_8033530"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-153",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 4
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/0c71da6b-e4be-43bc-bdcc-53304e4ab542.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/0c71da6b-e4be-43bc-bdcc-53304e4ab542.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8066555",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8066555",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0365",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "d58884ac86d49982bad0b95344d37eca.bam",
+            "fileSize": 78175816072,
+            "fileType": "BAM",
+            "fileMd5sum": "d58884ac86d49982bad0b95344d37eca",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "0c71da6b-e4be-43bc-bdcc-53304e4ab542",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "d58884ac86d49982bad0b95344d37eca.bam",
+            "file_r2": "d58884ac86d49982bad0b95344d37eca.bam",
+            "insert_size": 320,
+            "platform_unit": "QCMG:20131226010834524_8066555",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_NEW5709A2250AR5",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131226010834524",
+            "submitter_read_group_id": "QCMG:20131226010834524_8066555"
+        },
+        {
+            "file_r1": "d58884ac86d49982bad0b95344d37eca.bam",
+            "file_r2": "d58884ac86d49982bad0b95344d37eca.bam",
+            "insert_size": 319,
+            "platform_unit": "QCMG:20131226010835046_8066555",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_NEW5709A2250AR5",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131226010835046",
+            "submitter_read_group_id": "QCMG:20131226010835046_8066555"
+        },
+        {
+            "file_r1": "d58884ac86d49982bad0b95344d37eca.bam",
+            "file_r2": "d58884ac86d49982bad0b95344d37eca.bam",
+            "insert_size": 319,
+            "platform_unit": "QCMG:20131226010836563_8066555",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_NEW5709A2250AR5",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131226010836563",
+            "submitter_read_group_id": "QCMG:20131226010836563_8066555"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-189",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/13b58191-2a17-4c1a-a2fa-0be7339dc9cd.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/13b58191-2a17-4c1a-a2fa-0be7339dc9cd.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031139",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031139",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0109",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "0065a92ed68b3db0c39f023f8fea6be5.bam",
+            "fileSize": 87136547078,
+            "fileType": "BAM",
+            "fileMd5sum": "0065a92ed68b3db0c39f023f8fea6be5",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "13b58191-2a17-4c1a-a2fa-0be7339dc9cd",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "0065a92ed68b3db0c39f023f8fea6be5.bam",
+            "file_r2": "0065a92ed68b3db0c39f023f8fea6be5.bam",
+            "insert_size": 308,
+            "platform_unit": "QCMG:2013021709183030_8031139",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4932A1AR12",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013021709183030",
+            "submitter_read_group_id": "QCMG:2013021709183030_8031139"
+        },
+        {
+            "file_r1": "0065a92ed68b3db0c39f023f8fea6be5.bam",
+            "file_r2": "0065a92ed68b3db0c39f023f8fea6be5.bam",
+            "insert_size": 308,
+            "platform_unit": "QCMG:20130217114144295_8031139",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4932A1AR12",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130217114144295",
+            "submitter_read_group_id": "QCMG:20130217114144295_8031139"
+        },
+        {
+            "file_r1": "0065a92ed68b3db0c39f023f8fea6be5.bam",
+            "file_r2": "0065a92ed68b3db0c39f023f8fea6be5.bam",
+            "insert_size": 308,
+            "platform_unit": "QCMG:20130217114300925_8031139",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4932A1AR12",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130217114300925",
+            "submitter_read_group_id": "QCMG:20130217114300925_8031139"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-162",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/1453183f-4d66-4e33-b91f-099b09a51530.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/1453183f-4d66-4e33-b91f-099b09a51530.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8044442",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8044442",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0149",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "4658282d077b711d1a23a76fafd75555.bam",
+            "fileSize": 110637796015,
+            "fileType": "BAM",
+            "fileMd5sum": "4658282d077b711d1a23a76fafd75555",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "1453183f-4d66-4e33-b91f-099b09a51530",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "4658282d077b711d1a23a76fafd75555.bam",
+            "file_r2": "4658282d077b711d1a23a76fafd75555.bam",
+            "insert_size": 288,
+            "platform_unit": "QCMG:20130315012741703_8044442",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5455A1AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130315012741703",
+            "submitter_read_group_id": "QCMG:20130315012741703_8044442"
+        },
+        {
+            "file_r1": "4658282d077b711d1a23a76fafd75555.bam",
+            "file_r2": "4658282d077b711d1a23a76fafd75555.bam",
+            "insert_size": 288,
+            "platform_unit": "QCMG:20130315031616848_8044442",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5455A1AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130315031616848",
+            "submitter_read_group_id": "QCMG:20130315031616848_8044442"
+        },
+        {
+            "file_r1": "4658282d077b711d1a23a76fafd75555.bam",
+            "file_r2": "4658282d077b711d1a23a76fafd75555.bam",
+            "insert_size": 288,
+            "platform_unit": "QCMG:20130315101405947_8044442",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5455A1AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130315101405947",
+            "submitter_read_group_id": "QCMG:20130315101405947_8044442"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-151",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/1ca3a2c8-eb4b-4ee2-b11f-2e11901d43c5.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/1ca3a2c8-eb4b-4ee2-b11f-2e11901d43c5.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031068",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031068",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0105",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "89c04994455475c4a6073cf60f548211.bam",
+            "fileSize": 99169368571,
+            "fileType": "BAM",
+            "fileMd5sum": "89c04994455475c4a6073cf60f548211",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "1ca3a2c8-eb4b-4ee2-b11f-2e11901d43c5",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "89c04994455475c4a6073cf60f548211.bam",
+            "file_r2": "89c04994455475c4a6073cf60f548211.bam",
+            "insert_size": 399,
+            "platform_unit": "QCMG:20130410053411177_8031068",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_Q",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130410053411177",
+            "submitter_read_group_id": "QCMG:20130410053411177_8031068"
+        },
+        {
+            "file_r1": "89c04994455475c4a6073cf60f548211.bam",
+            "file_r2": "89c04994455475c4a6073cf60f548211.bam",
+            "insert_size": 398,
+            "platform_unit": "QCMG:20130410055339963_8031068",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_Q",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130410055339963",
+            "submitter_read_group_id": "QCMG:20130410055339963_8031068"
+        },
+        {
+            "file_r1": "89c04994455475c4a6073cf60f548211.bam",
+            "file_r2": "89c04994455475c4a6073cf60f548211.bam",
+            "insert_size": 399,
+            "platform_unit": "QCMG:20130410091529283_8031068",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_Q",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130410091529283",
+            "submitter_read_group_id": "QCMG:20130410091529283_8031068"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-130",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/1eebc2b3-5d6a-4541-8249-0533a8917da5.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/1eebc2b3-5d6a-4541-8249-0533a8917da5.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8044097",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8044097",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0114",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "be480277ce9265171a349903a2faf078.bam",
+            "fileSize": 106396862671,
+            "fileType": "BAM",
+            "fileMd5sum": "be480277ce9265171a349903a2faf078",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "1eebc2b3-5d6a-4541-8249-0533a8917da5",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "be480277ce9265171a349903a2faf078.bam",
+            "file_r2": "be480277ce9265171a349903a2faf078.bam",
+            "insert_size": 303,
+            "platform_unit": "QCMG:20130217104152308_8044097",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5262A1AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130217104152308",
+            "submitter_read_group_id": "QCMG:20130217104152308_8044097"
+        },
+        {
+            "file_r1": "be480277ce9265171a349903a2faf078.bam",
+            "file_r2": "be480277ce9265171a349903a2faf078.bam",
+            "insert_size": 302,
+            "platform_unit": "QCMG:20130217114609780_8044097",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5262A1AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130217114609780",
+            "submitter_read_group_id": "QCMG:20130217114609780_8044097"
+        },
+        {
+            "file_r1": "be480277ce9265171a349903a2faf078.bam",
+            "file_r2": "be480277ce9265171a349903a2faf078.bam",
+            "insert_size": 302,
+            "platform_unit": "QCMG:20130217114852791_8044097",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5262A1AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130217114852791",
+            "submitter_read_group_id": "QCMG:20130217114852791_8044097"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-128",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/2012efe6-b5bd-40cc-8dbb-21d9dccab3df.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/2012efe6-b5bd-40cc-8dbb-21d9dccab3df.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8069453",
+            "matchedNormalSubmitterSampleId": "8069455",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8069453",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0526",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "d47cff9b8b8bc11a96fa2c5c7cfb5305.bam",
+            "fileSize": 146396869020,
+            "fileType": "BAM",
+            "fileMd5sum": "d47cff9b8b8bc11a96fa2c5c7cfb5305",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "2012efe6-b5bd-40cc-8dbb-21d9dccab3df",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "d47cff9b8b8bc11a96fa2c5c7cfb5305.bam",
+            "file_r2": "d47cff9b8b8bc11a96fa2c5c7cfb5305.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140214232729044_8069453",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_R",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232729044",
+            "submitter_read_group_id": "QCMG:20140214232729044_8069453"
+        },
+        {
+            "file_r1": "d47cff9b8b8bc11a96fa2c5c7cfb5305.bam",
+            "file_r2": "d47cff9b8b8bc11a96fa2c5c7cfb5305.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140214232730260_8069453",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_R",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232730260",
+            "submitter_read_group_id": "QCMG:20140214232730260_8069453"
+        },
+        {
+            "file_r1": "d47cff9b8b8bc11a96fa2c5c7cfb5305.bam",
+            "file_r2": "d47cff9b8b8bc11a96fa2c5c7cfb5305.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140214232731673_8069453",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_R",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232731673",
+            "submitter_read_group_id": "QCMG:20140214232731673_8069453"
+        },
+        {
+            "file_r1": "d47cff9b8b8bc11a96fa2c5c7cfb5305.bam",
+            "file_r2": "d47cff9b8b8bc11a96fa2c5c7cfb5305.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140214232732735_8069453",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_R",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232732735",
+            "submitter_read_group_id": "QCMG:20140214232732735_8069453"
+        },
+        {
+            "file_r1": "d47cff9b8b8bc11a96fa2c5c7cfb5305.bam",
+            "file_r2": "d47cff9b8b8bc11a96fa2c5c7cfb5305.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140214232733187_8069453",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_R",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232733187",
+            "submitter_read_group_id": "QCMG:20140214232733187_8069453"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-177",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/256db1d2-512d-4a3e-8c0c-250a2daaf752.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/256db1d2-512d-4a3e-8c0c-250a2daaf752.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8035555",
+            "matchedNormalSubmitterSampleId": "8035561",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8035555",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0140",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "d87b71a040df901a4ebcfb51c3006388.bam",
+            "fileSize": 202642399201,
+            "fileType": "BAM",
+            "fileMd5sum": "d87b71a040df901a4ebcfb51c3006388",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "256db1d2-512d-4a3e-8c0c-250a2daaf752",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "d87b71a040df901a4ebcfb51c3006388.bam",
+            "file_r2": "d87b71a040df901a4ebcfb51c3006388.bam",
+            "insert_size": 280,
+            "platform_unit": "QCMG:20130315011441373_8035555",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5302A2AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130315011441373",
+            "submitter_read_group_id": "QCMG:20130315011441373_8035555"
+        },
+        {
+            "file_r1": "d87b71a040df901a4ebcfb51c3006388.bam",
+            "file_r2": "d87b71a040df901a4ebcfb51c3006388.bam",
+            "insert_size": 280,
+            "platform_unit": "QCMG:20130315020811684_8035555",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5302A2AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130315020811684",
+            "submitter_read_group_id": "QCMG:20130315020811684_8035555"
+        },
+        {
+            "file_r1": "d87b71a040df901a4ebcfb51c3006388.bam",
+            "file_r2": "d87b71a040df901a4ebcfb51c3006388.bam",
+            "insert_size": 279,
+            "platform_unit": "QCMG:20130315044436952_8035555",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5302A2AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130315044436952",
+            "submitter_read_group_id": "QCMG:20130315044436952_8035555"
+        },
+        {
+            "file_r1": "d87b71a040df901a4ebcfb51c3006388.bam",
+            "file_r2": "d87b71a040df901a4ebcfb51c3006388.bam",
+            "insert_size": 280,
+            "platform_unit": "QCMG:20130315045414384_8035555",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5302A2AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130315045414384",
+            "submitter_read_group_id": "QCMG:20130315045414384_8035555"
+        },
+        {
+            "file_r1": "d87b71a040df901a4ebcfb51c3006388.bam",
+            "file_r2": "d87b71a040df901a4ebcfb51c3006388.bam",
+            "insert_size": 280,
+            "platform_unit": "QCMG:20130315065142783_8035555",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5302A2AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130315065142783",
+            "submitter_read_group_id": "QCMG:20130315065142783_8035555"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-131",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/262b042e-1265-4673-95fd-7e6c6ab1384e.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/262b042e-1265-4673-95fd-7e6c6ab1384e.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057490",
+            "matchedNormalSubmitterSampleId": "8057487",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057490",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0224",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "a874ced6f1f0c47ca9509d82e9acef17.bam",
+            "fileSize": 110028061366,
+            "fileType": "BAM",
+            "fileMd5sum": "a874ced6f1f0c47ca9509d82e9acef17",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "262b042e-1265-4673-95fd-7e6c6ab1384e",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "a874ced6f1f0c47ca9509d82e9acef17.bam",
+            "file_r2": "a874ced6f1f0c47ca9509d82e9acef17.bam",
+            "insert_size": 414,
+            "platform_unit": "QCMG:20140211112908169_8057490",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20140124_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140211112908169",
+            "submitter_read_group_id": "QCMG:20140211112908169_8057490"
+        },
+        {
+            "file_r1": "a874ced6f1f0c47ca9509d82e9acef17.bam",
+            "file_r2": "a874ced6f1f0c47ca9509d82e9acef17.bam",
+            "insert_size": 414,
+            "platform_unit": "QCMG:20140212033317374_8057490",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20140124_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140212033317374",
+            "submitter_read_group_id": "QCMG:20140212033317374_8057490"
+        },
+        {
+            "file_r1": "a874ced6f1f0c47ca9509d82e9acef17.bam",
+            "file_r2": "a874ced6f1f0c47ca9509d82e9acef17.bam",
+            "insert_size": 414,
+            "platform_unit": "QCMG:2014021204354822_8057490",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20140124_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2014021204354822",
+            "submitter_read_group_id": "QCMG:2014021204354822_8057490"
+        },
+        {
+            "file_r1": "a874ced6f1f0c47ca9509d82e9acef17.bam",
+            "file_r2": "a874ced6f1f0c47ca9509d82e9acef17.bam",
+            "insert_size": 414,
+            "platform_unit": "QCMG:20140212122922871_8057490",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20140124_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140212122922871",
+            "submitter_read_group_id": "QCMG:20140212122922871_8057490"
+        },
+        {
+            "file_r1": "a874ced6f1f0c47ca9509d82e9acef17.bam",
+            "file_r2": "a874ced6f1f0c47ca9509d82e9acef17.bam",
+            "insert_size": 414,
+            "platform_unit": "QCMG:20140212124923599_8057490",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20140124_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140212124923599",
+            "submitter_read_group_id": "QCMG:20140212124923599_8057490"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-160",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/266afa38-2943-4403-b5d3-5e7f784623ed.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/266afa38-2943-4403-b5d3-5e7f784623ed.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8067541",
+            "matchedNormalSubmitterSampleId": "8013143",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8067541",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0020",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "8f2e9e2d9d23910e0f1eb64ff2d2fa7b.bam",
+            "fileSize": 148508462460,
+            "fileType": "BAM",
+            "fileMd5sum": "8f2e9e2d9d23910e0f1eb64ff2d2fa7b",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "266afa38-2943-4403-b5d3-5e7f784623ed",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "8f2e9e2d9d23910e0f1eb64ff2d2fa7b.bam",
+            "file_r2": "8f2e9e2d9d23910e0f1eb64ff2d2fa7b.bam",
+            "insert_size": 314,
+            "platform_unit": "QCMG:20140124172355416_8067541",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AG",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172355416",
+            "submitter_read_group_id": "QCMG:20140124172355416_8067541"
+        },
+        {
+            "file_r1": "8f2e9e2d9d23910e0f1eb64ff2d2fa7b.bam",
+            "file_r2": "8f2e9e2d9d23910e0f1eb64ff2d2fa7b.bam",
+            "insert_size": 313,
+            "platform_unit": "QCMG:20140124172356870_8067541",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AG",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172356870",
+            "submitter_read_group_id": "QCMG:20140124172356870_8067541"
+        },
+        {
+            "file_r1": "8f2e9e2d9d23910e0f1eb64ff2d2fa7b.bam",
+            "file_r2": "8f2e9e2d9d23910e0f1eb64ff2d2fa7b.bam",
+            "insert_size": 313,
+            "platform_unit": "QCMG:20140124172357161_8067541",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AG",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172357161",
+            "submitter_read_group_id": "QCMG:20140124172357161_8067541"
+        },
+        {
+            "file_r1": "8f2e9e2d9d23910e0f1eb64ff2d2fa7b.bam",
+            "file_r2": "8f2e9e2d9d23910e0f1eb64ff2d2fa7b.bam",
+            "insert_size": 313,
+            "platform_unit": "QCMG:20140124172358125_8067541",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AG",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172358125",
+            "submitter_read_group_id": "QCMG:20140124172358125_8067541"
+        },
+        {
+            "file_r1": "8f2e9e2d9d23910e0f1eb64ff2d2fa7b.bam",
+            "file_r2": "8f2e9e2d9d23910e0f1eb64ff2d2fa7b.bam",
+            "insert_size": 313,
+            "platform_unit": "QCMG:20140124172359140_8067541",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AG",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172359140",
+            "submitter_read_group_id": "QCMG:20140124172359140_8067541"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-181",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/273709c8-005f-4893-96ec-0edb9470531a.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/273709c8-005f-4893-96ec-0edb9470531a.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8049223",
+            "matchedNormalSubmitterSampleId": "8057709",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8049223",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0315",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "88cd73a9260c89bf776f30874c16c51d.bam",
+            "fileSize": 124726237260,
+            "fileType": "BAM",
+            "fileMd5sum": "88cd73a9260c89bf776f30874c16c51d",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "273709c8-005f-4893-96ec-0edb9470531a",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "88cd73a9260c89bf776f30874c16c51d.bam",
+            "file_r2": "88cd73a9260c89bf776f30874c16c51d.bam",
+            "insert_size": 381,
+            "platform_unit": "QCMG:20130424010151232_8049223",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130424010151232",
+            "submitter_read_group_id": "QCMG:20130424010151232_8049223"
+        },
+        {
+            "file_r1": "88cd73a9260c89bf776f30874c16c51d.bam",
+            "file_r2": "88cd73a9260c89bf776f30874c16c51d.bam",
+            "insert_size": 381,
+            "platform_unit": "QCMG:20130424010744151_8049223",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130424010744151",
+            "submitter_read_group_id": "QCMG:20130424010744151_8049223"
+        },
+        {
+            "file_r1": "88cd73a9260c89bf776f30874c16c51d.bam",
+            "file_r2": "88cd73a9260c89bf776f30874c16c51d.bam",
+            "insert_size": 381,
+            "platform_unit": "QCMG:20130424011026870_8049223",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130424011026870",
+            "submitter_read_group_id": "QCMG:20130424011026870_8049223"
+        },
+        {
+            "file_r1": "88cd73a9260c89bf776f30874c16c51d.bam",
+            "file_r2": "88cd73a9260c89bf776f30874c16c51d.bam",
+            "insert_size": 381,
+            "platform_unit": "QCMG:20130424014235602_8049223",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130424014235602",
+            "submitter_read_group_id": "QCMG:20130424014235602_8049223"
+        },
+        {
+            "file_r1": "88cd73a9260c89bf776f30874c16c51d.bam",
+            "file_r2": "88cd73a9260c89bf776f30874c16c51d.bam",
+            "insert_size": 381,
+            "platform_unit": "QCMG:20130424125811298_8049223",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130424125811298",
+            "submitter_read_group_id": "QCMG:20130424125811298_8049223"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-105",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/27bf0429-2864-4aad-b2ab-0f8dea1a26cf.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/27bf0429-2864-4aad-b2ab-0f8dea1a26cf.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057478",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057478",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0199",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "04a858ed943c25497d61f720f8ec4346.bam",
+            "fileSize": 68094581738,
+            "fileType": "BAM",
+            "fileMd5sum": "04a858ed943c25497d61f720f8ec4346",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "27bf0429-2864-4aad-b2ab-0f8dea1a26cf",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "04a858ed943c25497d61f720f8ec4346.bam",
+            "file_r2": "04a858ed943c25497d61f720f8ec4346.bam",
+            "insert_size": 385,
+            "platform_unit": "QCMG:20130507020943932_8057478",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130507020943932",
+            "submitter_read_group_id": "QCMG:20130507020943932_8057478"
+        },
+        {
+            "file_r1": "04a858ed943c25497d61f720f8ec4346.bam",
+            "file_r2": "04a858ed943c25497d61f720f8ec4346.bam",
+            "insert_size": 385,
+            "platform_unit": "QCMG:20130507040402129_8057478",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130507040402129",
+            "submitter_read_group_id": "QCMG:20130507040402129_8057478"
+        },
+        {
+            "file_r1": "04a858ed943c25497d61f720f8ec4346.bam",
+            "file_r2": "04a858ed943c25497d61f720f8ec4346.bam",
+            "insert_size": 387,
+            "platform_unit": "QCMG:2013050710575265_8057478",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013050710575265",
+            "submitter_read_group_id": "QCMG:2013050710575265_8057478"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-137",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/2898899f-94af-463e-9791-108da92d6a18.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/2898899f-94af-463e-9791-108da92d6a18.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031681",
+            "matchedNormalSubmitterSampleId": "8031686",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031681",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0066",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "f5136eb84f0dd7a9d366c9ae49e29b8f.bam",
+            "fileSize": 113221062439,
+            "fileType": "BAM",
+            "fileMd5sum": "f5136eb84f0dd7a9d366c9ae49e29b8f",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "2898899f-94af-463e-9791-108da92d6a18",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "f5136eb84f0dd7a9d366c9ae49e29b8f.bam",
+            "file_r2": "f5136eb84f0dd7a9d366c9ae49e29b8f.bam",
+            "insert_size": 374,
+            "platform_unit": "QCMG:20130725041843372_8031681",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130514_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130725041843372",
+            "submitter_read_group_id": "QCMG:20130725041843372_8031681"
+        },
+        {
+            "file_r1": "f5136eb84f0dd7a9d366c9ae49e29b8f.bam",
+            "file_r2": "f5136eb84f0dd7a9d366c9ae49e29b8f.bam",
+            "insert_size": 374,
+            "platform_unit": "QCMG:20130725044752631_8031681",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130514_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130725044752631",
+            "submitter_read_group_id": "QCMG:20130725044752631_8031681"
+        },
+        {
+            "file_r1": "f5136eb84f0dd7a9d366c9ae49e29b8f.bam",
+            "file_r2": "f5136eb84f0dd7a9d366c9ae49e29b8f.bam",
+            "insert_size": 374,
+            "platform_unit": "QCMG:20130725045332696_8031681",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130514_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130725045332696",
+            "submitter_read_group_id": "QCMG:20130725045332696_8031681"
+        },
+        {
+            "file_r1": "f5136eb84f0dd7a9d366c9ae49e29b8f.bam",
+            "file_r2": "f5136eb84f0dd7a9d366c9ae49e29b8f.bam",
+            "insert_size": 374,
+            "platform_unit": "QCMG:20130725054923184_8031681",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130514_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130725054923184",
+            "submitter_read_group_id": "QCMG:20130725054923184_8031681"
+        },
+        {
+            "file_r1": "f5136eb84f0dd7a9d366c9ae49e29b8f.bam",
+            "file_r2": "f5136eb84f0dd7a9d366c9ae49e29b8f.bam",
+            "insert_size": 374,
+            "platform_unit": "QCMG:20130725061223596_8031681",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130514_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130725061223596",
+            "submitter_read_group_id": "QCMG:20130725061223596_8031681"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-132",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/29e73e00-02bf-4204-b81e-7eb1b0b118b5.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/29e73e00-02bf-4204-b81e-7eb1b0b118b5.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057714",
+            "matchedNormalSubmitterSampleId": "8057716",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057714",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0296",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "f6f1f10aea1f0bcf66c8c4e4722cba1d.bam",
+            "fileSize": 138283546202,
+            "fileType": "BAM",
+            "fileMd5sum": "f6f1f10aea1f0bcf66c8c4e4722cba1d",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "29e73e00-02bf-4204-b81e-7eb1b0b118b5",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "f6f1f10aea1f0bcf66c8c4e4722cba1d.bam",
+            "file_r2": "f6f1f10aea1f0bcf66c8c4e4722cba1d.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:20130522082936875_8057714",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130415_I",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130522082936875",
+            "submitter_read_group_id": "QCMG:20130522082936875_8057714"
+        },
+        {
+            "file_r1": "f6f1f10aea1f0bcf66c8c4e4722cba1d.bam",
+            "file_r2": "f6f1f10aea1f0bcf66c8c4e4722cba1d.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:20130522083302295_8057714",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130415_I",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130522083302295",
+            "submitter_read_group_id": "QCMG:20130522083302295_8057714"
+        },
+        {
+            "file_r1": "f6f1f10aea1f0bcf66c8c4e4722cba1d.bam",
+            "file_r2": "f6f1f10aea1f0bcf66c8c4e4722cba1d.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:20130522083741801_8057714",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130415_I",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130522083741801",
+            "submitter_read_group_id": "QCMG:20130522083741801_8057714"
+        },
+        {
+            "file_r1": "f6f1f10aea1f0bcf66c8c4e4722cba1d.bam",
+            "file_r2": "f6f1f10aea1f0bcf66c8c4e4722cba1d.bam",
+            "insert_size": 377,
+            "platform_unit": "QCMG:20130522085021834_8057714",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130415_I",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130522085021834",
+            "submitter_read_group_id": "QCMG:20130522085021834_8057714"
+        },
+        {
+            "file_r1": "f6f1f10aea1f0bcf66c8c4e4722cba1d.bam",
+            "file_r2": "f6f1f10aea1f0bcf66c8c4e4722cba1d.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:20130523024512522_8057714",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130415_I",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130523024512522",
+            "submitter_read_group_id": "QCMG:20130523024512522_8057714"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-107",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/32c4c407-9b1c-4db7-915f-d6d3886f9fb2.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/32c4c407-9b1c-4db7-915f-d6d3886f9fb2.json
@@ -1,0 +1,127 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8066553",
+            "matchedNormalSubmitterSampleId": "8066555",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8066553",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0365",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "c155a46c76d37ff712bd701467b061e4.bam",
+            "fileSize": 216927712710,
+            "fileType": "BAM",
+            "fileMd5sum": "c155a46c76d37ff712bd701467b061e4",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "32c4c407-9b1c-4db7-915f-d6d3886f9fb2",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "c155a46c76d37ff712bd701467b061e4.bam",
+            "file_r2": "c155a46c76d37ff712bd701467b061e4.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140124172211675_8066553",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172211675",
+            "submitter_read_group_id": "QCMG:20140124172211675_8066553"
+        },
+        {
+            "file_r1": "c155a46c76d37ff712bd701467b061e4.bam",
+            "file_r2": "c155a46c76d37ff712bd701467b061e4.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140124172212833_8066553",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172212833",
+            "submitter_read_group_id": "QCMG:20140124172212833_8066553"
+        },
+        {
+            "file_r1": "c155a46c76d37ff712bd701467b061e4.bam",
+            "file_r2": "c155a46c76d37ff712bd701467b061e4.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140124172213285_8066553",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172213285",
+            "submitter_read_group_id": "QCMG:20140124172213285_8066553"
+        },
+        {
+            "file_r1": "c155a46c76d37ff712bd701467b061e4.bam",
+            "file_r2": "c155a46c76d37ff712bd701467b061e4.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140124172214123_8066553",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172214123",
+            "submitter_read_group_id": "QCMG:20140124172214123_8066553"
+        },
+        {
+            "file_r1": "c155a46c76d37ff712bd701467b061e4.bam",
+            "file_r2": "c155a46c76d37ff712bd701467b061e4.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140124172215514_8066553",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172215514",
+            "submitter_read_group_id": "QCMG:20140124172215514_8066553"
+        },
+        {
+            "file_r1": "c155a46c76d37ff712bd701467b061e4.bam",
+            "file_r2": "c155a46c76d37ff712bd701467b061e4.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140124172224831_8066553",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172224831",
+            "submitter_read_group_id": "QCMG:20140124172224831_8066553"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-178",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 6
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/37e9ca99-9ac7-4690-a952-487dfe0daadb.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/37e9ca99-9ac7-4690-a952-487dfe0daadb.json
@@ -1,0 +1,127 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8044091",
+            "matchedNormalSubmitterSampleId": "8044097",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8044091",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0114",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "fileSize": 189006464734,
+            "fileType": "BAM",
+            "fileMd5sum": "82b7986d332ba56bbd6f9ecdfd88c234",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "37e9ca99-9ac7-4690-a952-487dfe0daadb",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "file_r2": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "insert_size": 299,
+            "platform_unit": "QCMG:20130315114840766_8044091",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5262A2AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130315114840766",
+            "submitter_read_group_id": "QCMG:20130315114840766_8044091"
+        },
+        {
+            "file_r1": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "file_r2": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "insert_size": 299,
+            "platform_unit": "QCMG:20130316010755199_8044091",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5262A2AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130316010755199",
+            "submitter_read_group_id": "QCMG:20130316010755199_8044091"
+        },
+        {
+            "file_r1": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "file_r2": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "insert_size": 299,
+            "platform_unit": "QCMG:20130316011517181_8044091",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5262A2AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130316011517181",
+            "submitter_read_group_id": "QCMG:20130316011517181_8044091"
+        },
+        {
+            "file_r1": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "file_r2": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "insert_size": 299,
+            "platform_unit": "QCMG:20130316011525922_8044091",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5262A2AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130316011525922",
+            "submitter_read_group_id": "QCMG:20130316011525922_8044091"
+        },
+        {
+            "file_r1": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "file_r2": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "insert_size": 299,
+            "platform_unit": "QCMG:2013031601252610_8044091",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5262A2AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013031601252610",
+            "submitter_read_group_id": "QCMG:2013031601252610_8044091"
+        },
+        {
+            "file_r1": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "file_r2": "82b7986d332ba56bbd6f9ecdfd88c234.bam",
+            "insert_size": 299,
+            "platform_unit": "QCMG:20130316124226309_8044091",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5262A2AR4",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130316124226309",
+            "submitter_read_group_id": "QCMG:20130316124226309_8044091"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-143",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 6
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/42eddcf6-96e5-4769-94c5-1a1669bff945.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/42eddcf6-96e5-4769-94c5-1a1669bff945.json
@@ -1,0 +1,101 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8064559",
+            "matchedNormalSubmitterSampleId": "8015265",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8064559",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0053",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "63a4fc3e658453a77d5404c03b96a7e9.bam",
+            "fileSize": 117284090368,
+            "fileType": "BAM",
+            "fileMd5sum": "63a4fc3e658453a77d5404c03b96a7e9",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "42eddcf6-96e5-4769-94c5-1a1669bff945",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "63a4fc3e658453a77d5404c03b96a7e9.bam",
+            "file_r2": "63a4fc3e658453a77d5404c03b96a7e9.bam",
+            "insert_size": 359,
+            "platform_unit": "QCMG:20130725091539127_8064559",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130626_C",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130725091539127",
+            "submitter_read_group_id": "QCMG:20130725091539127_8064559"
+        },
+        {
+            "file_r1": "63a4fc3e658453a77d5404c03b96a7e9.bam",
+            "file_r2": "63a4fc3e658453a77d5404c03b96a7e9.bam",
+            "insert_size": 359,
+            "platform_unit": "QCMG:2013072510104787_8064559",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130626_C",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013072510104787",
+            "submitter_read_group_id": "QCMG:2013072510104787_8064559"
+        },
+        {
+            "file_r1": "63a4fc3e658453a77d5404c03b96a7e9.bam",
+            "file_r2": "63a4fc3e658453a77d5404c03b96a7e9.bam",
+            "insert_size": 360,
+            "platform_unit": "QCMG:20130725103009990_8064559",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130626_C",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130725103009990",
+            "submitter_read_group_id": "QCMG:20130725103009990_8064559"
+        },
+        {
+            "file_r1": "63a4fc3e658453a77d5404c03b96a7e9.bam",
+            "file_r2": "63a4fc3e658453a77d5404c03b96a7e9.bam",
+            "insert_size": 359,
+            "platform_unit": "QCMG:2013072511065618_8064559",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130626_C",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013072511065618",
+            "submitter_read_group_id": "QCMG:2013072511065618_8064559"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-106",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 4
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/44905698-39d2-4a1d-bc8a-95159759c0b7.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/44905698-39d2-4a1d-bc8a-95159759c0b7.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8068588",
+            "matchedNormalSubmitterSampleId": "8057629",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8068588",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0227",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "9ed8005c0958232f0cc5dc22cb770947.bam",
+            "fileSize": 154460143757,
+            "fileType": "BAM",
+            "fileMd5sum": "9ed8005c0958232f0cc5dc22cb770947",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "44905698-39d2-4a1d-bc8a-95159759c0b7",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "9ed8005c0958232f0cc5dc22cb770947.bam",
+            "file_r2": "9ed8005c0958232f0cc5dc22cb770947.bam",
+            "insert_size": 314,
+            "platform_unit": "QCMG:20140214232736262_8068588",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_Q",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232736262",
+            "submitter_read_group_id": "QCMG:20140214232736262_8068588"
+        },
+        {
+            "file_r1": "9ed8005c0958232f0cc5dc22cb770947.bam",
+            "file_r2": "9ed8005c0958232f0cc5dc22cb770947.bam",
+            "insert_size": 314,
+            "platform_unit": "QCMG:20140214232737247_8068588",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_Q",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232737247",
+            "submitter_read_group_id": "QCMG:20140214232737247_8068588"
+        },
+        {
+            "file_r1": "9ed8005c0958232f0cc5dc22cb770947.bam",
+            "file_r2": "9ed8005c0958232f0cc5dc22cb770947.bam",
+            "insert_size": 314,
+            "platform_unit": "QCMG:20140214232738660_8068588",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_Q",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232738660",
+            "submitter_read_group_id": "QCMG:20140214232738660_8068588"
+        },
+        {
+            "file_r1": "9ed8005c0958232f0cc5dc22cb770947.bam",
+            "file_r2": "9ed8005c0958232f0cc5dc22cb770947.bam",
+            "insert_size": 314,
+            "platform_unit": "QCMG:20140214232739624_8068588",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_Q",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232739624",
+            "submitter_read_group_id": "QCMG:20140214232739624_8068588"
+        },
+        {
+            "file_r1": "9ed8005c0958232f0cc5dc22cb770947.bam",
+            "file_r2": "9ed8005c0958232f0cc5dc22cb770947.bam",
+            "insert_size": 314,
+            "platform_unit": "QCMG:20140214232740221_8068588",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_Q",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232740221",
+            "submitter_read_group_id": "QCMG:20140214232740221_8068588"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-138",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/464b94bc-766c-4d51-b99c-54e25a349c9b.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/464b94bc-766c-4d51-b99c-54e25a349c9b.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031103",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031103",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0099",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "0beef8ef4f55ff27ff431ae373674c63.bam",
+            "fileSize": 74939903227,
+            "fileType": "BAM",
+            "fileMd5sum": "0beef8ef4f55ff27ff431ae373674c63",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "464b94bc-766c-4d51-b99c-54e25a349c9b",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "0beef8ef4f55ff27ff431ae373674c63.bam",
+            "file_r2": "0beef8ef4f55ff27ff431ae373674c63.bam",
+            "insert_size": 319,
+            "platform_unit": "QCMG:20131226010810035_8031103",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4920A1AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131226010810035",
+            "submitter_read_group_id": "QCMG:20131226010810035_8031103"
+        },
+        {
+            "file_r1": "0beef8ef4f55ff27ff431ae373674c63.bam",
+            "file_r2": "0beef8ef4f55ff27ff431ae373674c63.bam",
+            "insert_size": 319,
+            "platform_unit": "QCMG:20131226010811355_8031103",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4920A1AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131226010811355",
+            "submitter_read_group_id": "QCMG:20131226010811355_8031103"
+        },
+        {
+            "file_r1": "0beef8ef4f55ff27ff431ae373674c63.bam",
+            "file_r2": "0beef8ef4f55ff27ff431ae373674c63.bam",
+            "insert_size": 318,
+            "platform_unit": "QCMG:20131226010812681_8031103",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4920A1AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131226010812681",
+            "submitter_read_group_id": "QCMG:20131226010812681_8031103"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-111",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/49f1d6a6-5e32-47fd-91b0-51b0273a5726.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/49f1d6a6-5e32-47fd-91b0-51b0273a5726.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031710",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031710",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0207",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "76b6bf2c976a0c43709d12373cbfdd58.bam",
+            "fileSize": 111058242699,
+            "fileType": "BAM",
+            "fileMd5sum": "76b6bf2c976a0c43709d12373cbfdd58",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "49f1d6a6-5e32-47fd-91b0-51b0273a5726",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "76b6bf2c976a0c43709d12373cbfdd58.bam",
+            "file_r2": "76b6bf2c976a0c43709d12373cbfdd58.bam",
+            "insert_size": 313,
+            "platform_unit": "QCMG:20130309022100586_8031710",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4938A1AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309022100586",
+            "submitter_read_group_id": "QCMG:20130309022100586_8031710"
+        },
+        {
+            "file_r1": "76b6bf2c976a0c43709d12373cbfdd58.bam",
+            "file_r2": "76b6bf2c976a0c43709d12373cbfdd58.bam",
+            "insert_size": 314,
+            "platform_unit": "QCMG:2013030904551414_8031710",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4938A1AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013030904551414",
+            "submitter_read_group_id": "QCMG:2013030904551414_8031710"
+        },
+        {
+            "file_r1": "76b6bf2c976a0c43709d12373cbfdd58.bam",
+            "file_r2": "76b6bf2c976a0c43709d12373cbfdd58.bam",
+            "insert_size": 314,
+            "platform_unit": "QCMG:20130309053100425_8031710",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4938A1AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309053100425",
+            "submitter_read_group_id": "QCMG:20130309053100425_8031710"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-158",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/4a827ce0-0271-44c4-bb84-19ebb0e3dce8.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/4a827ce0-0271-44c4-bb84-19ebb0e3dce8.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8016492",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8016492",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0054",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "ff06adcfd723eb892a2dcc8b286a41b7.bam",
+            "fileSize": 95127852936,
+            "fileType": "BAM",
+            "fileMd5sum": "0c2384a250e48646a58c10b079538e76",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "4a827ce0-0271-44c4-bb84-19ebb0e3dce8",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "ff06adcfd723eb892a2dcc8b286a41b7.bam",
+            "file_r2": "ff06adcfd723eb892a2dcc8b286a41b7.bam",
+            "insert_size": 295,
+            "platform_unit": "QCMG:20120812103803363_8016492",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20120726_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20120812103803363",
+            "submitter_read_group_id": "QCMG:20120812103803363_8016492"
+        },
+        {
+            "file_r1": "ff06adcfd723eb892a2dcc8b286a41b7.bam",
+            "file_r2": "ff06adcfd723eb892a2dcc8b286a41b7.bam",
+            "insert_size": 295,
+            "platform_unit": "QCMG:20120813090919842_8016492",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20120726_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20120813090919842",
+            "submitter_read_group_id": "QCMG:20120813090919842_8016492"
+        },
+        {
+            "file_r1": "ff06adcfd723eb892a2dcc8b286a41b7.bam",
+            "file_r2": "ff06adcfd723eb892a2dcc8b286a41b7.bam",
+            "insert_size": 295,
+            "platform_unit": "QCMG:20120816053240799_8016492",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20120726_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20120816053240799",
+            "submitter_read_group_id": "QCMG:20120816053240799_8016492"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-144",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/4e66a7a1-8f08-4cb9-9ad2-5de83f7716e6.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/4e66a7a1-8f08-4cb9-9ad2-5de83f7716e6.json
@@ -1,0 +1,101 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8016486",
+            "matchedNormalSubmitterSampleId": "8016492",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8016486",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0054",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "8416f331a680366c1a0ddcb819d7c7cc.bam",
+            "fileSize": 82935553829,
+            "fileType": "BAM",
+            "fileMd5sum": "8416f331a680366c1a0ddcb819d7c7cc",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "4e66a7a1-8f08-4cb9-9ad2-5de83f7716e6",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "8416f331a680366c1a0ddcb819d7c7cc.bam",
+            "file_r2": "8416f331a680366c1a0ddcb819d7c7cc.bam",
+            "insert_size": 380,
+            "platform_unit": "QCMG:20131004014051860_8016486",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_D",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131004014051860",
+            "submitter_read_group_id": "QCMG:20131004014051860_8016486"
+        },
+        {
+            "file_r1": "8416f331a680366c1a0ddcb819d7c7cc.bam",
+            "file_r2": "8416f331a680366c1a0ddcb819d7c7cc.bam",
+            "insert_size": 379,
+            "platform_unit": "QCMG:20131004014358536_8016486",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_D",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131004014358536",
+            "submitter_read_group_id": "QCMG:20131004014358536_8016486"
+        },
+        {
+            "file_r1": "8416f331a680366c1a0ddcb819d7c7cc.bam",
+            "file_r2": "8416f331a680366c1a0ddcb819d7c7cc.bam",
+            "insert_size": 379,
+            "platform_unit": "QCMG:20131004023724212_8016486",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_D",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131004023724212",
+            "submitter_read_group_id": "QCMG:20131004023724212_8016486"
+        },
+        {
+            "file_r1": "8416f331a680366c1a0ddcb819d7c7cc.bam",
+            "file_r2": "8416f331a680366c1a0ddcb819d7c7cc.bam",
+            "insert_size": 379,
+            "platform_unit": "QCMG:20131004040320327_8016486",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_D",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131004040320327",
+            "submitter_read_group_id": "QCMG:20131004040320327_8016486"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-149",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 4
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/5265252a-d41a-43ef-a06b-2406ce2a265c.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/5265252a-d41a-43ef-a06b-2406ce2a265c.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057481",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057481",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0201",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "697e9eaba76f0227204d7a16528c7652.bam",
+            "fileSize": 93168986410,
+            "fileType": "BAM",
+            "fileMd5sum": "697e9eaba76f0227204d7a16528c7652",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "5265252a-d41a-43ef-a06b-2406ce2a265c",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "697e9eaba76f0227204d7a16528c7652.bam",
+            "file_r2": "697e9eaba76f0227204d7a16528c7652.bam",
+            "insert_size": 392,
+            "platform_unit": "QCMG:20130329051123158_8057481",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_I",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130329051123158",
+            "submitter_read_group_id": "QCMG:20130329051123158_8057481"
+        },
+        {
+            "file_r1": "697e9eaba76f0227204d7a16528c7652.bam",
+            "file_r2": "697e9eaba76f0227204d7a16528c7652.bam",
+            "insert_size": 392,
+            "platform_unit": "QCMG:20130329055450131_8057481",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_I",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130329055450131",
+            "submitter_read_group_id": "QCMG:20130329055450131_8057481"
+        },
+        {
+            "file_r1": "697e9eaba76f0227204d7a16528c7652.bam",
+            "file_r2": "697e9eaba76f0227204d7a16528c7652.bam",
+            "insert_size": 394,
+            "platform_unit": "QCMG:20130329123235832_8057481",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_I",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130329123235832",
+            "submitter_read_group_id": "QCMG:20130329123235832_8057481"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-121",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/52f44ff4-aefb-4ff2-963c-8b64dfb28b71.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/52f44ff4-aefb-4ff2-963c-8b64dfb28b71.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8035633",
+            "matchedNormalSubmitterSampleId": "8035639",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8035633",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0212",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "4fb7ac23ccae45c170d3770d4549998e.bam",
+            "fileSize": 206298708954,
+            "fileType": "BAM",
+            "fileMd5sum": "4fb7ac23ccae45c170d3770d4549998e",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "52f44ff4-aefb-4ff2-963c-8b64dfb28b71",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "4fb7ac23ccae45c170d3770d4549998e.bam",
+            "file_r2": "4fb7ac23ccae45c170d3770d4549998e.bam",
+            "insert_size": 290,
+            "platform_unit": "QCMG:20130309100100823_8035633",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5265A2AR8",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309100100823",
+            "submitter_read_group_id": "QCMG:20130309100100823_8035633"
+        },
+        {
+            "file_r1": "4fb7ac23ccae45c170d3770d4549998e.bam",
+            "file_r2": "4fb7ac23ccae45c170d3770d4549998e.bam",
+            "insert_size": 290,
+            "platform_unit": "QCMG:20130309101800446_8035633",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5265A2AR8",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309101800446",
+            "submitter_read_group_id": "QCMG:20130309101800446_8035633"
+        },
+        {
+            "file_r1": "4fb7ac23ccae45c170d3770d4549998e.bam",
+            "file_r2": "4fb7ac23ccae45c170d3770d4549998e.bam",
+            "insert_size": 289,
+            "platform_unit": "QCMG:20130309115823594_8035633",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5265A2AR8",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309115823594",
+            "submitter_read_group_id": "QCMG:20130309115823594_8035633"
+        },
+        {
+            "file_r1": "4fb7ac23ccae45c170d3770d4549998e.bam",
+            "file_r2": "4fb7ac23ccae45c170d3770d4549998e.bam",
+            "insert_size": 289,
+            "platform_unit": "QCMG:201303091215244_8035633",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5265A2AR8",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:201303091215244",
+            "submitter_read_group_id": "QCMG:201303091215244_8035633"
+        },
+        {
+            "file_r1": "4fb7ac23ccae45c170d3770d4549998e.bam",
+            "file_r2": "4fb7ac23ccae45c170d3770d4549998e.bam",
+            "insert_size": 289,
+            "platform_unit": "QCMG:20130309122829539_8035633",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5265A2AR8",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309122829539",
+            "submitter_read_group_id": "QCMG:20130309122829539_8035633"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-100",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/55d00f11-9d0d-484b-9ac7-0a1a22288a5a.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/55d00f11-9d0d-484b-9ac7-0a1a22288a5a.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8067176",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8067176",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0391",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "22c6e298281cf1ba2fccac1a9c6ee6d5.bam",
+            "fileSize": 77343933899,
+            "fileType": "BAM",
+            "fileMd5sum": "22c6e298281cf1ba2fccac1a9c6ee6d5",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "55d00f11-9d0d-484b-9ac7-0a1a22288a5a",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "22c6e298281cf1ba2fccac1a9c6ee6d5.bam",
+            "file_r2": "22c6e298281cf1ba2fccac1a9c6ee6d5.bam",
+            "insert_size": 316,
+            "platform_unit": "QCMG:20131226010739026_8067176",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_NEW5709A2423AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131226010739026",
+            "submitter_read_group_id": "QCMG:20131226010739026_8067176"
+        },
+        {
+            "file_r1": "22c6e298281cf1ba2fccac1a9c6ee6d5.bam",
+            "file_r2": "22c6e298281cf1ba2fccac1a9c6ee6d5.bam",
+            "insert_size": 317,
+            "platform_unit": "QCMG:20131226010808726_8067176",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_NEW5709A2423AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131226010808726",
+            "submitter_read_group_id": "QCMG:20131226010808726_8067176"
+        },
+        {
+            "file_r1": "22c6e298281cf1ba2fccac1a9c6ee6d5.bam",
+            "file_r2": "22c6e298281cf1ba2fccac1a9c6ee6d5.bam",
+            "insert_size": 317,
+            "platform_unit": "QCMG:20131226010809028_8067176",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_NEW5709A2423AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131226010809028",
+            "submitter_read_group_id": "QCMG:20131226010809028_8067176"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-170",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/5980cc32-7290-4248-8427-2ddcfae987fb.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/5980cc32-7290-4248-8427-2ddcfae987fb.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031704",
+            "matchedNormalSubmitterSampleId": "8031710",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031704",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0207",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "7229248390a3f10e747b946e5ef580a8.bam",
+            "fileSize": 198867952193,
+            "fileType": "BAM",
+            "fileMd5sum": "7229248390a3f10e747b946e5ef580a8",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "5980cc32-7290-4248-8427-2ddcfae987fb",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "7229248390a3f10e747b946e5ef580a8.bam",
+            "file_r2": "7229248390a3f10e747b946e5ef580a8.bam",
+            "insert_size": 282,
+            "platform_unit": "QCMG:20130201113140929_8031704",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4938A2AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130201113140929",
+            "submitter_read_group_id": "QCMG:20130201113140929_8031704"
+        },
+        {
+            "file_r1": "7229248390a3f10e747b946e5ef580a8.bam",
+            "file_r2": "7229248390a3f10e747b946e5ef580a8.bam",
+            "insert_size": 282,
+            "platform_unit": "QCMG:20130202055304588_8031704",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4938A2AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130202055304588",
+            "submitter_read_group_id": "QCMG:20130202055304588_8031704"
+        },
+        {
+            "file_r1": "7229248390a3f10e747b946e5ef580a8.bam",
+            "file_r2": "7229248390a3f10e747b946e5ef580a8.bam",
+            "insert_size": 281,
+            "platform_unit": "QCMG:20130202074417462_8031704",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4938A2AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130202074417462",
+            "submitter_read_group_id": "QCMG:20130202074417462_8031704"
+        },
+        {
+            "file_r1": "7229248390a3f10e747b946e5ef580a8.bam",
+            "file_r2": "7229248390a3f10e747b946e5ef580a8.bam",
+            "insert_size": 281,
+            "platform_unit": "QCMG:20130202094424308_8031704",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4938A2AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130202094424308",
+            "submitter_read_group_id": "QCMG:20130202094424308_8031704"
+        },
+        {
+            "file_r1": "7229248390a3f10e747b946e5ef580a8.bam",
+            "file_r2": "7229248390a3f10e747b946e5ef580a8.bam",
+            "insert_size": 282,
+            "platform_unit": "QCMG:20130202112617698_8031704",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4938A2AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130202112617698",
+            "submitter_read_group_id": "QCMG:20130202112617698_8031704"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-125",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/5d53fc53-704f-4477-a812-32cf0a9a994d.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/5d53fc53-704f-4477-a812-32cf0a9a994d.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8068976",
+            "matchedNormalSubmitterSampleId": "8069318",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8068976",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0502",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "d81c21b115e5380151c42b193d64d93f.bam",
+            "fileSize": 159302722665,
+            "fileType": "BAM",
+            "fileMd5sum": "d81c21b115e5380151c42b193d64d93f",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "5d53fc53-704f-4477-a812-32cf0a9a994d",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "d81c21b115e5380151c42b193d64d93f.bam",
+            "file_r2": "d81c21b115e5380151c42b193d64d93f.bam",
+            "insert_size": 322,
+            "platform_unit": "QCMG:20140214232633861_8068976",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232633861",
+            "submitter_read_group_id": "QCMG:20140214232633861_8068976"
+        },
+        {
+            "file_r1": "d81c21b115e5380151c42b193d64d93f.bam",
+            "file_r2": "d81c21b115e5380151c42b193d64d93f.bam",
+            "insert_size": 322,
+            "platform_unit": "QCMG:20140214232634886_8068976",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232634886",
+            "submitter_read_group_id": "QCMG:20140214232634886_8068976"
+        },
+        {
+            "file_r1": "d81c21b115e5380151c42b193d64d93f.bam",
+            "file_r2": "d81c21b115e5380151c42b193d64d93f.bam",
+            "insert_size": 322,
+            "platform_unit": "QCMG:20140214232635514_8068976",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232635514",
+            "submitter_read_group_id": "QCMG:20140214232635514_8068976"
+        },
+        {
+            "file_r1": "d81c21b115e5380151c42b193d64d93f.bam",
+            "file_r2": "d81c21b115e5380151c42b193d64d93f.bam",
+            "insert_size": 323,
+            "platform_unit": "QCMG:20140214232636138_8068976",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232636138",
+            "submitter_read_group_id": "QCMG:20140214232636138_8068976"
+        },
+        {
+            "file_r1": "d81c21b115e5380151c42b193d64d93f.bam",
+            "file_r2": "d81c21b115e5380151c42b193d64d93f.bam",
+            "insert_size": 324,
+            "platform_unit": "QCMG:20140214232637313_8068976",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232637313",
+            "submitter_read_group_id": "QCMG:20140214232637313_8068976"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-176",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/5f8e83a1-5888-4ec1-ab5d-e8a4c1d92fa6.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/5f8e83a1-5888-4ec1-ab5d-e8a4c1d92fa6.json
@@ -1,0 +1,127 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8044424",
+            "matchedNormalSubmitterSampleId": "8044430",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8044424",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0153",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "fileSize": 222297171029,
+            "fileType": "BAM",
+            "fileMd5sum": "14f89baf0ffda6131e330f41c1fc1ee6",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "5f8e83a1-5888-4ec1-ab5d-e8a4c1d92fa6",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "file_r2": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20130309022125284_8044424",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5456A2AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309022125284",
+            "submitter_read_group_id": "QCMG:20130309022125284_8044424"
+        },
+        {
+            "file_r1": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "file_r2": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20130309023139364_8044424",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5456A2AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309023139364",
+            "submitter_read_group_id": "QCMG:20130309023139364_8044424"
+        },
+        {
+            "file_r1": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "file_r2": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20130309030223634_8044424",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5456A2AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309030223634",
+            "submitter_read_group_id": "QCMG:20130309030223634_8044424"
+        },
+        {
+            "file_r1": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "file_r2": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20130309085012192_8044424",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5456A2AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309085012192",
+            "submitter_read_group_id": "QCMG:20130309085012192_8044424"
+        },
+        {
+            "file_r1": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "file_r2": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20130309093916338_8044424",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5456A2AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309093916338",
+            "submitter_read_group_id": "QCMG:20130309093916338_8044424"
+        },
+        {
+            "file_r1": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "file_r2": "14f89baf0ffda6131e330f41c1fc1ee6.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:2013030910262781_8044424",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5456A2AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013030910262781",
+            "submitter_read_group_id": "QCMG:2013030910262781_8044424"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-139",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 6
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/60c5f34c-46bc-4472-9522-0249242eed49.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/60c5f34c-46bc-4472-9522-0249242eed49.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8069439",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8069439",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0518",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "83d2e20c87f849512d343195c7da6909.bam",
+            "fileSize": 79603841560,
+            "fileType": "BAM",
+            "fileMd5sum": "83d2e20c87f849512d343195c7da6909",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "60c5f34c-46bc-4472-9522-0249242eed49",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "83d2e20c87f849512d343195c7da6909.bam",
+            "file_r2": "83d2e20c87f849512d343195c7da6909.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140214232802143_8069439",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AB",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232802143",
+            "submitter_read_group_id": "QCMG:20140214232802143_8069439"
+        },
+        {
+            "file_r1": "83d2e20c87f849512d343195c7da6909.bam",
+            "file_r2": "83d2e20c87f849512d343195c7da6909.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140214232803051_8069439",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AB",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232803051",
+            "submitter_read_group_id": "QCMG:20140214232803051_8069439"
+        },
+        {
+            "file_r1": "83d2e20c87f849512d343195c7da6909.bam",
+            "file_r2": "83d2e20c87f849512d343195c7da6909.bam",
+            "insert_size": 307,
+            "platform_unit": "QCMG:20140214232813634_8069439",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AB",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232813634",
+            "submitter_read_group_id": "QCMG:20140214232813634_8069439"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-165",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/61152212-73f5-4470-a0a1-867ab3f1d271.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/61152212-73f5-4470-a0a1-867ab3f1d271.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8030360",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8030360",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0063",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "bee45a9cd3045afbaf08f657a7af40e9.bam",
+            "fileSize": 100954629983,
+            "fileType": "BAM",
+            "fileMd5sum": "bee45a9cd3045afbaf08f657a7af40e9",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "61152212-73f5-4470-a0a1-867ab3f1d271",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "bee45a9cd3045afbaf08f657a7af40e9.bam",
+            "file_r2": "bee45a9cd3045afbaf08f657a7af40e9.bam",
+            "insert_size": 301,
+            "platform_unit": "QCMG:20130218090640418_8030360",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4927A1AR20",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130218090640418",
+            "submitter_read_group_id": "QCMG:20130218090640418_8030360"
+        },
+        {
+            "file_r1": "bee45a9cd3045afbaf08f657a7af40e9.bam",
+            "file_r2": "bee45a9cd3045afbaf08f657a7af40e9.bam",
+            "insert_size": 301,
+            "platform_unit": "QCMG:20130218094600765_8030360",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4927A1AR20",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130218094600765",
+            "submitter_read_group_id": "QCMG:20130218094600765_8030360"
+        },
+        {
+            "file_r1": "bee45a9cd3045afbaf08f657a7af40e9.bam",
+            "file_r2": "bee45a9cd3045afbaf08f657a7af40e9.bam",
+            "insert_size": 301,
+            "platform_unit": "QCMG:20130218100548427_8030360",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4927A1AR20",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130218100548427",
+            "submitter_read_group_id": "QCMG:20130218100548427_8030360"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-115",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/637ffbb5-8325-4847-9e61-563919815a41.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/637ffbb5-8325-4847-9e61-563919815a41.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057688",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057688",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0192",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "3607e63b10624e468876ebb0fa2c97af.bam",
+            "fileSize": 80315918998,
+            "fileType": "BAM",
+            "fileMd5sum": "3607e63b10624e468876ebb0fa2c97af",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "637ffbb5-8325-4847-9e61-563919815a41",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "3607e63b10624e468876ebb0fa2c97af.bam",
+            "file_r2": "3607e63b10624e468876ebb0fa2c97af.bam",
+            "insert_size": 313,
+            "platform_unit": "QCMG:20140124172125626_8057688",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172125626",
+            "submitter_read_group_id": "QCMG:20140124172125626_8057688"
+        },
+        {
+            "file_r1": "3607e63b10624e468876ebb0fa2c97af.bam",
+            "file_r2": "3607e63b10624e468876ebb0fa2c97af.bam",
+            "insert_size": 314,
+            "platform_unit": "QCMG:20140124172126102_8057688",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172126102",
+            "submitter_read_group_id": "QCMG:20140124172126102_8057688"
+        },
+        {
+            "file_r1": "3607e63b10624e468876ebb0fa2c97af.bam",
+            "file_r2": "3607e63b10624e468876ebb0fa2c97af.bam",
+            "insert_size": 314,
+            "platform_unit": "QCMG:20140124172127763_8057688",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172127763",
+            "submitter_read_group_id": "QCMG:20140124172127763_8057688"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-117",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/6666937e-04c1-4dc6-b31b-6be6ce3c7086.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/6666937e-04c1-4dc6-b31b-6be6ce3c7086.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8069326",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8069326",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0507",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "dd3be4c3d6362df13ac3cc15841cf392.bam",
+            "fileSize": 85318557435,
+            "fileType": "BAM",
+            "fileMd5sum": "dd3be4c3d6362df13ac3cc15841cf392",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "6666937e-04c1-4dc6-b31b-6be6ce3c7086",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "dd3be4c3d6362df13ac3cc15841cf392.bam",
+            "file_r2": "dd3be4c3d6362df13ac3cc15841cf392.bam",
+            "insert_size": 301,
+            "platform_unit": "QCMG:20140214232617680_8069326",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AE",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232617680",
+            "submitter_read_group_id": "QCMG:20140214232617680_8069326"
+        },
+        {
+            "file_r1": "dd3be4c3d6362df13ac3cc15841cf392.bam",
+            "file_r2": "dd3be4c3d6362df13ac3cc15841cf392.bam",
+            "insert_size": 301,
+            "platform_unit": "QCMG:20140214232618527_8069326",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AE",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232618527",
+            "submitter_read_group_id": "QCMG:20140214232618527_8069326"
+        },
+        {
+            "file_r1": "dd3be4c3d6362df13ac3cc15841cf392.bam",
+            "file_r2": "dd3be4c3d6362df13ac3cc15841cf392.bam",
+            "insert_size": 300,
+            "platform_unit": "QCMG:20140214232814434_8069326",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AE",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232814434",
+            "submitter_read_group_id": "QCMG:20140214232814434_8069326"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-179",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/66c37a00-f5b6-4548-bcf4-f6a3cc79f965.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/66c37a00-f5b6-4548-bcf4-f6a3cc79f965.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8051974",
+            "matchedNormalSubmitterSampleId": "8051975",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8051974",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0214",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "3470971e6c18c820173413ef1f654edc.bam",
+            "fileSize": 128634332013,
+            "fileType": "BAM",
+            "fileMd5sum": "3470971e6c18c820173413ef1f654edc",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "66c37a00-f5b6-4548-bcf4-f6a3cc79f965",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "3470971e6c18c820173413ef1f654edc.bam",
+            "file_r2": "3470971e6c18c820173413ef1f654edc.bam",
+            "insert_size": 403,
+            "platform_unit": "QCMG:20130416021046114_8051974",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416021046114",
+            "submitter_read_group_id": "QCMG:20130416021046114_8051974"
+        },
+        {
+            "file_r1": "3470971e6c18c820173413ef1f654edc.bam",
+            "file_r2": "3470971e6c18c820173413ef1f654edc.bam",
+            "insert_size": 403,
+            "platform_unit": "QCMG:20130416021805316_8051974",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416021805316",
+            "submitter_read_group_id": "QCMG:20130416021805316_8051974"
+        },
+        {
+            "file_r1": "3470971e6c18c820173413ef1f654edc.bam",
+            "file_r2": "3470971e6c18c820173413ef1f654edc.bam",
+            "insert_size": 403,
+            "platform_unit": "QCMG:20130416023027376_8051974",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416023027376",
+            "submitter_read_group_id": "QCMG:20130416023027376_8051974"
+        },
+        {
+            "file_r1": "3470971e6c18c820173413ef1f654edc.bam",
+            "file_r2": "3470971e6c18c820173413ef1f654edc.bam",
+            "insert_size": 403,
+            "platform_unit": "QCMG:20130416102122779_8051974",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416102122779",
+            "submitter_read_group_id": "QCMG:20130416102122779_8051974"
+        },
+        {
+            "file_r1": "3470971e6c18c820173413ef1f654edc.bam",
+            "file_r2": "3470971e6c18c820173413ef1f654edc.bam",
+            "insert_size": 403,
+            "platform_unit": "QCMG:20130416104423691_8051974",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416104423691",
+            "submitter_read_group_id": "QCMG:20130416104423691_8051974"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-150",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/67e2a06a-97af-4fc1-bcc4-e9097f54ee29.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/67e2a06a-97af-4fc1-bcc4-e9097f54ee29.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057677",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057677",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0185",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "4aca27d4e428e39ceff88879ac09c48f.bam",
+            "fileSize": 84390906054,
+            "fileType": "BAM",
+            "fileMd5sum": "4aca27d4e428e39ceff88879ac09c48f",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "67e2a06a-97af-4fc1-bcc4-e9097f54ee29",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "4aca27d4e428e39ceff88879ac09c48f.bam",
+            "file_r2": "4aca27d4e428e39ceff88879ac09c48f.bam",
+            "insert_size": 399,
+            "platform_unit": "QCMG:20130423034006768_8057677",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_U",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130423034006768",
+            "submitter_read_group_id": "QCMG:20130423034006768_8057677"
+        },
+        {
+            "file_r1": "4aca27d4e428e39ceff88879ac09c48f.bam",
+            "file_r2": "4aca27d4e428e39ceff88879ac09c48f.bam",
+            "insert_size": 399,
+            "platform_unit": "QCMG:201304230403493_8057677",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_U",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:201304230403493",
+            "submitter_read_group_id": "QCMG:201304230403493_8057677"
+        },
+        {
+            "file_r1": "4aca27d4e428e39ceff88879ac09c48f.bam",
+            "file_r2": "4aca27d4e428e39ceff88879ac09c48f.bam",
+            "insert_size": 398,
+            "platform_unit": "QCMG:20130423044631903_8057677",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_U",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130423044631903",
+            "submitter_read_group_id": "QCMG:20130423044631903_8057677"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-147",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/692813f3-131f-4b2d-a37a-a3d2a7cc4c6a.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/692813f3-131f-4b2d-a37a-a3d2a7cc4c6a.json
@@ -1,0 +1,75 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8068549",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8068549",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0124",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "d3c76e35055e601169e6eb068c71712c.bam",
+            "fileSize": 60556465944,
+            "fileType": "BAM",
+            "fileMd5sum": "d3c76e35055e601169e6eb068c71712c",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "692813f3-131f-4b2d-a37a-a3d2a7cc4c6a",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "d3c76e35055e601169e6eb068c71712c.bam",
+            "file_r2": "d3c76e35055e601169e6eb068c71712c.bam",
+            "insert_size": 306,
+            "platform_unit": "QCMG:20140214232747535_8068549",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_X",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232747535",
+            "submitter_read_group_id": "QCMG:20140214232747535_8068549"
+        },
+        {
+            "file_r1": "d3c76e35055e601169e6eb068c71712c.bam",
+            "file_r2": "d3c76e35055e601169e6eb068c71712c.bam",
+            "insert_size": 306,
+            "platform_unit": "QCMG:20140214232748684_8068549",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_X",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232748684",
+            "submitter_read_group_id": "QCMG:20140214232748684_8068549"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-174",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 2
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/6964c63c-7cf9-4e99-a442-302e55a8635c.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/6964c63c-7cf9-4e99-a442-302e55a8635c.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031085",
+            "matchedNormalSubmitterSampleId": "8031068",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031085",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0105",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "7e80c3544c8a6cc3e2551387fa5fa537.bam",
+            "fileSize": 180687434585,
+            "fileType": "BAM",
+            "fileMd5sum": "7e80c3544c8a6cc3e2551387fa5fa537",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "6964c63c-7cf9-4e99-a442-302e55a8635c",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "7e80c3544c8a6cc3e2551387fa5fa537.bam",
+            "file_r2": "7e80c3544c8a6cc3e2551387fa5fa537.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:20130410044327521_8031085",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_P",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130410044327521",
+            "submitter_read_group_id": "QCMG:20130410044327521_8031085"
+        },
+        {
+            "file_r1": "7e80c3544c8a6cc3e2551387fa5fa537.bam",
+            "file_r2": "7e80c3544c8a6cc3e2551387fa5fa537.bam",
+            "insert_size": 377,
+            "platform_unit": "QCMG:20130410082530569_8031085",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_P",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130410082530569",
+            "submitter_read_group_id": "QCMG:20130410082530569_8031085"
+        },
+        {
+            "file_r1": "7e80c3544c8a6cc3e2551387fa5fa537.bam",
+            "file_r2": "7e80c3544c8a6cc3e2551387fa5fa537.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:20130410091431523_8031085",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_P",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130410091431523",
+            "submitter_read_group_id": "QCMG:20130410091431523_8031085"
+        },
+        {
+            "file_r1": "7e80c3544c8a6cc3e2551387fa5fa537.bam",
+            "file_r2": "7e80c3544c8a6cc3e2551387fa5fa537.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:20130410091506346_8031085",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_P",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130410091506346",
+            "submitter_read_group_id": "QCMG:20130410091506346_8031085"
+        },
+        {
+            "file_r1": "7e80c3544c8a6cc3e2551387fa5fa537.bam",
+            "file_r2": "7e80c3544c8a6cc3e2551387fa5fa537.bam",
+            "insert_size": 377,
+            "platform_unit": "QCMG:20130410093526555_8031085",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_P",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130410093526555",
+            "submitter_read_group_id": "QCMG:20130410093526555_8031085"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-134",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/6de106d2-7fdf-4e04-bf0d-b6aed17be699.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/6de106d2-7fdf-4e04-bf0d-b6aed17be699.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057482",
+            "matchedNormalSubmitterSampleId": "8057481",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057482",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0201",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "6d40dc59523c89c44b88035bd6a8f4eb.bam",
+            "fileSize": 157255437436,
+            "fileType": "BAM",
+            "fileMd5sum": "6d40dc59523c89c44b88035bd6a8f4eb",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "6de106d2-7fdf-4e04-bf0d-b6aed17be699",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "6d40dc59523c89c44b88035bd6a8f4eb.bam",
+            "file_r2": "6d40dc59523c89c44b88035bd6a8f4eb.bam",
+            "insert_size": 386,
+            "platform_unit": "QCMG:20130329023927214_8057482",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130329023927214",
+            "submitter_read_group_id": "QCMG:20130329023927214_8057482"
+        },
+        {
+            "file_r1": "6d40dc59523c89c44b88035bd6a8f4eb.bam",
+            "file_r2": "6d40dc59523c89c44b88035bd6a8f4eb.bam",
+            "insert_size": 385,
+            "platform_unit": "QCMG:20130329065539728_8057482",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130329065539728",
+            "submitter_read_group_id": "QCMG:20130329065539728_8057482"
+        },
+        {
+            "file_r1": "6d40dc59523c89c44b88035bd6a8f4eb.bam",
+            "file_r2": "6d40dc59523c89c44b88035bd6a8f4eb.bam",
+            "insert_size": 384,
+            "platform_unit": "QCMG:20130329080313859_8057482",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130329080313859",
+            "submitter_read_group_id": "QCMG:20130329080313859_8057482"
+        },
+        {
+            "file_r1": "6d40dc59523c89c44b88035bd6a8f4eb.bam",
+            "file_r2": "6d40dc59523c89c44b88035bd6a8f4eb.bam",
+            "insert_size": 385,
+            "platform_unit": "QCMG:20130329085152890_8057482",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130329085152890",
+            "submitter_read_group_id": "QCMG:20130329085152890_8057482"
+        },
+        {
+            "file_r1": "6d40dc59523c89c44b88035bd6a8f4eb.bam",
+            "file_r2": "6d40dc59523c89c44b88035bd6a8f4eb.bam",
+            "insert_size": 386,
+            "platform_unit": "QCMG:20130329091659176_8057482",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130329091659176",
+            "submitter_read_group_id": "QCMG:20130329091659176_8057482"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-133",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/6f272a37-3b30-4ff3-9e3d-a936bc5cd00f.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/6f272a37-3b30-4ff3-9e3d-a936bc5cd00f.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8052151",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8052151",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0217",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "3ff7118f1c972cfe3a857890e45b24ff.bam",
+            "fileSize": 70819834604,
+            "fileType": "BAM",
+            "fileMd5sum": "3ff7118f1c972cfe3a857890e45b24ff",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "6f272a37-3b30-4ff3-9e3d-a936bc5cd00f",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "3ff7118f1c972cfe3a857890e45b24ff.bam",
+            "file_r2": "3ff7118f1c972cfe3a857890e45b24ff.bam",
+            "insert_size": 388,
+            "platform_unit": "QCMG:20131205032741921_8052151",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131205032741921",
+            "submitter_read_group_id": "QCMG:20131205032741921_8052151"
+        },
+        {
+            "file_r1": "3ff7118f1c972cfe3a857890e45b24ff.bam",
+            "file_r2": "3ff7118f1c972cfe3a857890e45b24ff.bam",
+            "insert_size": 387,
+            "platform_unit": "QCMG:2013120504262051_8052151",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013120504262051",
+            "submitter_read_group_id": "QCMG:2013120504262051_8052151"
+        },
+        {
+            "file_r1": "3ff7118f1c972cfe3a857890e45b24ff.bam",
+            "file_r2": "3ff7118f1c972cfe3a857890e45b24ff.bam",
+            "insert_size": 387,
+            "platform_unit": "QCMG:2013120506094880_8052151",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013120506094880",
+            "submitter_read_group_id": "QCMG:2013120506094880_8052151"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-113",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/7087fe76-a077-479a-b9b2-64c643918eaf.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/7087fe76-a077-479a-b9b2-64c643918eaf.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8044061",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8044061",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0150",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "80b9c20b55f9b3e020c9812fb0f5de48.bam",
+            "fileSize": 61208725708,
+            "fileType": "BAM",
+            "fileMd5sum": "80b9c20b55f9b3e020c9812fb0f5de48",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "7087fe76-a077-479a-b9b2-64c643918eaf",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "80b9c20b55f9b3e020c9812fb0f5de48.bam",
+            "file_r2": "80b9c20b55f9b3e020c9812fb0f5de48.bam",
+            "insert_size": 392,
+            "platform_unit": "QCMG:20131130014101577_8044061",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131130014101577",
+            "submitter_read_group_id": "QCMG:20131130014101577_8044061"
+        },
+        {
+            "file_r1": "80b9c20b55f9b3e020c9812fb0f5de48.bam",
+            "file_r2": "80b9c20b55f9b3e020c9812fb0f5de48.bam",
+            "insert_size": 392,
+            "platform_unit": "QCMG:2013113002260245_8044061",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013113002260245",
+            "submitter_read_group_id": "QCMG:2013113002260245_8044061"
+        },
+        {
+            "file_r1": "80b9c20b55f9b3e020c9812fb0f5de48.bam",
+            "file_r2": "80b9c20b55f9b3e020c9812fb0f5de48.bam",
+            "insert_size": 391,
+            "platform_unit": "QCMG:20131130112305755_8044061",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131130112305755",
+            "submitter_read_group_id": "QCMG:20131130112305755_8044061"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-173",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/749d4492-d6e0-47d8-b1ae-aa040a04fb46.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/749d4492-d6e0-47d8-b1ae-aa040a04fb46.json
@@ -1,0 +1,127 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8068579",
+            "matchedNormalSubmitterSampleId": "8058180",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8068579",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0301",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "fileSize": 185229778084,
+            "fileType": "BAM",
+            "fileMd5sum": "a186f48f629bf8acae5cfb5e9f69ccd4",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "749d4492-d6e0-47d8-b1ae-aa040a04fb46",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "file_r2": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "insert_size": 319,
+            "platform_unit": "QCMG:20140124172333000_8068579",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AB",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172333000",
+            "submitter_read_group_id": "QCMG:20140124172333000_8068579"
+        },
+        {
+            "file_r1": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "file_r2": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "insert_size": 319,
+            "platform_unit": "QCMG:20140124172334617_8068579",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AB",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172334617",
+            "submitter_read_group_id": "QCMG:20140124172334617_8068579"
+        },
+        {
+            "file_r1": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "file_r2": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "insert_size": 319,
+            "platform_unit": "QCMG:20140124172335048_8068579",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AB",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172335048",
+            "submitter_read_group_id": "QCMG:20140124172335048_8068579"
+        },
+        {
+            "file_r1": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "file_r2": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "insert_size": 319,
+            "platform_unit": "QCMG:20140124172336738_8068579",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AB",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172336738",
+            "submitter_read_group_id": "QCMG:20140124172336738_8068579"
+        },
+        {
+            "file_r1": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "file_r2": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "insert_size": 319,
+            "platform_unit": "QCMG:20140124172337536_8068579",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AB",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172337536",
+            "submitter_read_group_id": "QCMG:20140124172337536_8068579"
+        },
+        {
+            "file_r1": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "file_r2": "a186f48f629bf8acae5cfb5e9f69ccd4.bam",
+            "insert_size": 318,
+            "platform_unit": "QCMG:20140124172338743_8068579",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AB",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172338743",
+            "submitter_read_group_id": "QCMG:20140124172338743_8068579"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-103",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 6
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/779c0d87-550c-4793-a975-2f487d2291ca.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/779c0d87-550c-4793-a975-2f487d2291ca.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8069443",
+            "matchedNormalSubmitterSampleId": "8069445",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8069443",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0521",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "eab2a77a417ba427fd6ff4c09fa6e470.bam",
+            "fileSize": 157620436169,
+            "fileType": "BAM",
+            "fileMd5sum": "eab2a77a417ba427fd6ff4c09fa6e470",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "779c0d87-550c-4793-a975-2f487d2291ca",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "eab2a77a417ba427fd6ff4c09fa6e470.bam",
+            "file_r2": "eab2a77a417ba427fd6ff4c09fa6e470.bam",
+            "insert_size": 300,
+            "platform_unit": "QCMG:20140214232708818_8069443",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232708818",
+            "submitter_read_group_id": "QCMG:20140214232708818_8069443"
+        },
+        {
+            "file_r1": "eab2a77a417ba427fd6ff4c09fa6e470.bam",
+            "file_r2": "eab2a77a417ba427fd6ff4c09fa6e470.bam",
+            "insert_size": 300,
+            "platform_unit": "QCMG:20140214232709830_8069443",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232709830",
+            "submitter_read_group_id": "QCMG:20140214232709830_8069443"
+        },
+        {
+            "file_r1": "eab2a77a417ba427fd6ff4c09fa6e470.bam",
+            "file_r2": "eab2a77a417ba427fd6ff4c09fa6e470.bam",
+            "insert_size": 298,
+            "platform_unit": "QCMG:20140214232710771_8069443",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232710771",
+            "submitter_read_group_id": "QCMG:20140214232710771_8069443"
+        },
+        {
+            "file_r1": "eab2a77a417ba427fd6ff4c09fa6e470.bam",
+            "file_r2": "eab2a77a417ba427fd6ff4c09fa6e470.bam",
+            "insert_size": 300,
+            "platform_unit": "QCMG:20140214232711475_8069443",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232711475",
+            "submitter_read_group_id": "QCMG:20140214232711475_8069443"
+        },
+        {
+            "file_r1": "eab2a77a417ba427fd6ff4c09fa6e470.bam",
+            "file_r2": "eab2a77a417ba427fd6ff4c09fa6e470.bam",
+            "insert_size": 300,
+            "platform_unit": "QCMG:20140214232712621_8069443",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232712621",
+            "submitter_read_group_id": "QCMG:20140214232712621_8069443"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-184",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/7abdfc00-4c28-456e-8ad8-93b22f6ee3a1.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/7abdfc00-4c28-456e-8ad8-93b22f6ee3a1.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057716",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057716",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0296",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "b5ee46dafb64fa1ecda4810308b46b75.bam",
+            "fileSize": 84916407580,
+            "fileType": "BAM",
+            "fileMd5sum": "b5ee46dafb64fa1ecda4810308b46b75",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "7abdfc00-4c28-456e-8ad8-93b22f6ee3a1",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "b5ee46dafb64fa1ecda4810308b46b75.bam",
+            "file_r2": "b5ee46dafb64fa1ecda4810308b46b75.bam",
+            "insert_size": 370,
+            "platform_unit": "QCMG:20130522083743673_8057716",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130415_J",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130522083743673",
+            "submitter_read_group_id": "QCMG:20130522083743673_8057716"
+        },
+        {
+            "file_r1": "b5ee46dafb64fa1ecda4810308b46b75.bam",
+            "file_r2": "b5ee46dafb64fa1ecda4810308b46b75.bam",
+            "insert_size": 370,
+            "platform_unit": "QCMG:20130522084814350_8057716",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130415_J",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130522084814350",
+            "submitter_read_group_id": "QCMG:20130522084814350_8057716"
+        },
+        {
+            "file_r1": "b5ee46dafb64fa1ecda4810308b46b75.bam",
+            "file_r2": "b5ee46dafb64fa1ecda4810308b46b75.bam",
+            "insert_size": 370,
+            "platform_unit": "QCMG:20130523023055573_8057716",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130415_J",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130523023055573",
+            "submitter_read_group_id": "QCMG:20130523023055573_8057716"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-146",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/8362c695-de54-45fd-ac86-aef3f81a39f8.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/8362c695-de54-45fd-ac86-aef3f81a39f8.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8068554",
+            "matchedNormalSubmitterSampleId": "8057688",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8068554",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0192",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "a4c607921d25148339ca1f7ccb7c0f33.bam",
+            "fileSize": 156133213841,
+            "fileType": "BAM",
+            "fileMd5sum": "a4c607921d25148339ca1f7ccb7c0f33",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "8362c695-de54-45fd-ac86-aef3f81a39f8",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "a4c607921d25148339ca1f7ccb7c0f33.bam",
+            "file_r2": "a4c607921d25148339ca1f7ccb7c0f33.bam",
+            "insert_size": 300,
+            "platform_unit": "QCMG:20140124172400016_8068554",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AH",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172400016",
+            "submitter_read_group_id": "QCMG:20140124172400016_8068554"
+        },
+        {
+            "file_r1": "a4c607921d25148339ca1f7ccb7c0f33.bam",
+            "file_r2": "a4c607921d25148339ca1f7ccb7c0f33.bam",
+            "insert_size": 300,
+            "platform_unit": "QCMG:20140124172401880_8068554",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AH",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172401880",
+            "submitter_read_group_id": "QCMG:20140124172401880_8068554"
+        },
+        {
+            "file_r1": "a4c607921d25148339ca1f7ccb7c0f33.bam",
+            "file_r2": "a4c607921d25148339ca1f7ccb7c0f33.bam",
+            "insert_size": 300,
+            "platform_unit": "QCMG:20140124172402154_8068554",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AH",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172402154",
+            "submitter_read_group_id": "QCMG:20140124172402154_8068554"
+        },
+        {
+            "file_r1": "a4c607921d25148339ca1f7ccb7c0f33.bam",
+            "file_r2": "a4c607921d25148339ca1f7ccb7c0f33.bam",
+            "insert_size": 300,
+            "platform_unit": "QCMG:20140124172403417_8068554",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AH",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172403417",
+            "submitter_read_group_id": "QCMG:20140124172403417_8068554"
+        },
+        {
+            "file_r1": "a4c607921d25148339ca1f7ccb7c0f33.bam",
+            "file_r2": "a4c607921d25148339ca1f7ccb7c0f33.bam",
+            "insert_size": 301,
+            "platform_unit": "QCMG:20140124172404875_8068554",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AH",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172404875",
+            "submitter_read_group_id": "QCMG:20140124172404875_8068554"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-152",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/86ea9ba8-37c3-48ad-99f1-d969476b6c3b.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/86ea9ba8-37c3-48ad-99f1-d969476b6c3b.json
@@ -1,0 +1,127 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031146",
+            "matchedNormalSubmitterSampleId": "8031139",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031146",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0109",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "fileSize": 251761268976,
+            "fileType": "BAM",
+            "fileMd5sum": "0ba71a24c1f47034ae615fb72db96d74",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "86ea9ba8-37c3-48ad-99f1-d969476b6c3b",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "file_r2": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "insert_size": 289,
+            "platform_unit": "QCMG:20130309011239706_8031146",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4932A2AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309011239706",
+            "submitter_read_group_id": "QCMG:20130309011239706_8031146"
+        },
+        {
+            "file_r1": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "file_r2": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "insert_size": 289,
+            "platform_unit": "QCMG:20130309014739542_8031146",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4932A2AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309014739542",
+            "submitter_read_group_id": "QCMG:20130309014739542_8031146"
+        },
+        {
+            "file_r1": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "file_r2": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "insert_size": 289,
+            "platform_unit": "QCMG:20130309022547489_8031146",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4932A2AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309022547489",
+            "submitter_read_group_id": "QCMG:20130309022547489_8031146"
+        },
+        {
+            "file_r1": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "file_r2": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "insert_size": 289,
+            "platform_unit": "QCMG:20130309023052887_8031146",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4932A2AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309023052887",
+            "submitter_read_group_id": "QCMG:20130309023052887_8031146"
+        },
+        {
+            "file_r1": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "file_r2": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "insert_size": 290,
+            "platform_unit": "QCMG:20130309105624920_8031146",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4932A2AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309105624920",
+            "submitter_read_group_id": "QCMG:20130309105624920_8031146"
+        },
+        {
+            "file_r1": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "file_r2": "0ba71a24c1f47034ae615fb72db96d74.bam",
+            "insert_size": 289,
+            "platform_unit": "QCMG:20130309124701949_8031146",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4932A2AR10",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309124701949",
+            "submitter_read_group_id": "QCMG:20130309124701949_8031146"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-110",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 6
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/8d91311e-d69a-4d43-a440-9d5bc215c222.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/8d91311e-d69a-4d43-a440-9d5bc215c222.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8058184",
+            "matchedNormalSubmitterSampleId": "8058186",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8058184",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0303",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "f37a338db7184f1013cdfdc5909d604d.bam",
+            "fileSize": 96494271301,
+            "fileType": "BAM",
+            "fileMd5sum": "f37a338db7184f1013cdfdc5909d604d",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "8d91311e-d69a-4d43-a440-9d5bc215c222",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "f37a338db7184f1013cdfdc5909d604d.bam",
+            "file_r2": "f37a338db7184f1013cdfdc5909d604d.bam",
+            "insert_size": 381,
+            "platform_unit": "QCMG:20131009010607370_8058184",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131009010607370",
+            "submitter_read_group_id": "QCMG:20131009010607370_8058184"
+        },
+        {
+            "file_r1": "f37a338db7184f1013cdfdc5909d604d.bam",
+            "file_r2": "f37a338db7184f1013cdfdc5909d604d.bam",
+            "insert_size": 381,
+            "platform_unit": "QCMG:20131009011305230_8058184",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131009011305230",
+            "submitter_read_group_id": "QCMG:20131009011305230_8058184"
+        },
+        {
+            "file_r1": "f37a338db7184f1013cdfdc5909d604d.bam",
+            "file_r2": "f37a338db7184f1013cdfdc5909d604d.bam",
+            "insert_size": 381,
+            "platform_unit": "QCMG:20131009012132396_8058184",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131009012132396",
+            "submitter_read_group_id": "QCMG:20131009012132396_8058184"
+        },
+        {
+            "file_r1": "f37a338db7184f1013cdfdc5909d604d.bam",
+            "file_r2": "f37a338db7184f1013cdfdc5909d604d.bam",
+            "insert_size": 381,
+            "platform_unit": "QCMG:20131009115849984_8058184",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131009115849984",
+            "submitter_read_group_id": "QCMG:20131009115849984_8058184"
+        },
+        {
+            "file_r1": "f37a338db7184f1013cdfdc5909d604d.bam",
+            "file_r2": "f37a338db7184f1013cdfdc5909d604d.bam",
+            "insert_size": 381,
+            "platform_unit": "QCMG:20131009124238649_8058184",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131009124238649",
+            "submitter_read_group_id": "QCMG:20131009124238649_8058184"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-172",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/9242f37e-5775-4c3d-a98a-1290c30b45ab.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/9242f37e-5775-4c3d-a98a-1290c30b45ab.json
@@ -1,0 +1,153 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8033523",
+            "matchedNormalSubmitterSampleId": "8033530",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8033523",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0087",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "fileSize": 252960854046,
+            "fileType": "BAM",
+            "fileMd5sum": "f3c84ab40e0139fde05787bc853da2b5",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "9242f37e-5775-4c3d-a98a-1290c30b45ab",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "file_r2": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "insert_size": 393,
+            "platform_unit": "QCMG:20121212094704679_8033523",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121120_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20121212094704679",
+            "submitter_read_group_id": "QCMG:20121212094704679_8033523"
+        },
+        {
+            "file_r1": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "file_r2": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "insert_size": 394,
+            "platform_unit": "QCMG:20121212105404604_8033523",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121120_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20121212105404604",
+            "submitter_read_group_id": "QCMG:20121212105404604_8033523"
+        },
+        {
+            "file_r1": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "file_r2": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "insert_size": 395,
+            "platform_unit": "QCMG:20130207061531928_8033523",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121120_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130207061531928",
+            "submitter_read_group_id": "QCMG:20130207061531928_8033523"
+        },
+        {
+            "file_r1": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "file_r2": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "insert_size": 396,
+            "platform_unit": "QCMG:20130207065419937_8033523",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121120_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130207065419937",
+            "submitter_read_group_id": "QCMG:20130207065419937_8033523"
+        },
+        {
+            "file_r1": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "file_r2": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "insert_size": 396,
+            "platform_unit": "QCMG:20130207074324177_8033523",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121120_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130207074324177",
+            "submitter_read_group_id": "QCMG:20130207074324177_8033523"
+        },
+        {
+            "file_r1": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "file_r2": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "insert_size": 394,
+            "platform_unit": "QCMG:20130207084304873_8033523",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121120_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130207084304873",
+            "submitter_read_group_id": "QCMG:20130207084304873_8033523"
+        },
+        {
+            "file_r1": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "file_r2": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "insert_size": 395,
+            "platform_unit": "QCMG:2013020709003465_8033523",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121120_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013020709003465",
+            "submitter_read_group_id": "QCMG:2013020709003465_8033523"
+        },
+        {
+            "file_r1": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "file_r2": "f3c84ab40e0139fde05787bc853da2b5.bam",
+            "insert_size": 395,
+            "platform_unit": "QCMG:20130207093626562_8033523",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121120_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130207093626562",
+            "submitter_read_group_id": "QCMG:20130207093626562_8033523"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-164",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 8
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/92ca7970-c4e2-4563-91f1-540cde05805a.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/92ca7970-c4e2-4563-91f1-540cde05805a.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8043971",
+            "matchedNormalSubmitterSampleId": "8043977",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8043971",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0141",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "807f31654a837dc051e52c4a63aa14db.bam",
+            "fileSize": 113361251365,
+            "fileType": "BAM",
+            "fileMd5sum": "807f31654a837dc051e52c4a63aa14db",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "92ca7970-c4e2-4563-91f1-540cde05805a",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "807f31654a837dc051e52c4a63aa14db.bam",
+            "file_r2": "807f31654a837dc051e52c4a63aa14db.bam",
+            "insert_size": 250,
+            "platform_unit": "QCMG:20120929010056922_8043971",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20120829_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20120929010056922",
+            "submitter_read_group_id": "QCMG:20120929010056922_8043971"
+        },
+        {
+            "file_r1": "807f31654a837dc051e52c4a63aa14db.bam",
+            "file_r2": "807f31654a837dc051e52c4a63aa14db.bam",
+            "insert_size": 251,
+            "platform_unit": "QCMG:20120929022858635_8043971",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20120829_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20120929022858635",
+            "submitter_read_group_id": "QCMG:20120929022858635_8043971"
+        },
+        {
+            "file_r1": "807f31654a837dc051e52c4a63aa14db.bam",
+            "file_r2": "807f31654a837dc051e52c4a63aa14db.bam",
+            "insert_size": 250,
+            "platform_unit": "QCMG:20120929034859182_8043971",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20120829_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20120929034859182",
+            "submitter_read_group_id": "QCMG:20120929034859182_8043971"
+        },
+        {
+            "file_r1": "807f31654a837dc051e52c4a63aa14db.bam",
+            "file_r2": "807f31654a837dc051e52c4a63aa14db.bam",
+            "insert_size": 250,
+            "platform_unit": "QCMG:20120929035731204_8043971",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20120829_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20120929035731204",
+            "submitter_read_group_id": "QCMG:20120929035731204_8043971"
+        },
+        {
+            "file_r1": "807f31654a837dc051e52c4a63aa14db.bam",
+            "file_r2": "807f31654a837dc051e52c4a63aa14db.bam",
+            "insert_size": 251,
+            "platform_unit": "QCMG:20120929045643664_8043971",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20120829_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20120929045643664",
+            "submitter_read_group_id": "QCMG:20120929045643664_8043971"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-104",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/97c61f77-4054-40d2-b7c1-c90514156eaf.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/97c61f77-4054-40d2-b7c1-c90514156eaf.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057479",
+            "matchedNormalSubmitterSampleId": "8057478",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057479",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0199",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "b0438ca7eaa7eda3d10c27a65807bc74.bam",
+            "fileSize": 124155069069,
+            "fileType": "BAM",
+            "fileMd5sum": "b0438ca7eaa7eda3d10c27a65807bc74",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "97c61f77-4054-40d2-b7c1-c90514156eaf",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "b0438ca7eaa7eda3d10c27a65807bc74.bam",
+            "file_r2": "b0438ca7eaa7eda3d10c27a65807bc74.bam",
+            "insert_size": 380,
+            "platform_unit": "QCMG:20130507034248532_8057479",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130507034248532",
+            "submitter_read_group_id": "QCMG:20130507034248532_8057479"
+        },
+        {
+            "file_r1": "b0438ca7eaa7eda3d10c27a65807bc74.bam",
+            "file_r2": "b0438ca7eaa7eda3d10c27a65807bc74.bam",
+            "insert_size": 380,
+            "platform_unit": "QCMG:2013050705082313_8057479",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013050705082313",
+            "submitter_read_group_id": "QCMG:2013050705082313_8057479"
+        },
+        {
+            "file_r1": "b0438ca7eaa7eda3d10c27a65807bc74.bam",
+            "file_r2": "b0438ca7eaa7eda3d10c27a65807bc74.bam",
+            "insert_size": 380,
+            "platform_unit": "QCMG:20130507061533475_8057479",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130507061533475",
+            "submitter_read_group_id": "QCMG:20130507061533475_8057479"
+        },
+        {
+            "file_r1": "b0438ca7eaa7eda3d10c27a65807bc74.bam",
+            "file_r2": "b0438ca7eaa7eda3d10c27a65807bc74.bam",
+            "insert_size": 380,
+            "platform_unit": "QCMG:20130507065614846_8057479",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130507065614846",
+            "submitter_read_group_id": "QCMG:20130507065614846_8057479"
+        },
+        {
+            "file_r1": "b0438ca7eaa7eda3d10c27a65807bc74.bam",
+            "file_r2": "b0438ca7eaa7eda3d10c27a65807bc74.bam",
+            "insert_size": 380,
+            "platform_unit": "QCMG:20130507072702348_8057479",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130507072702348",
+            "submitter_read_group_id": "QCMG:20130507072702348_8057479"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-112",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/97e0bc54-6396-4ffc-9b32-e1a4f9c05739.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/97e0bc54-6396-4ffc-9b32-e1a4f9c05739.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8065126",
+            "matchedNormalSubmitterSampleId": "8052151",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8065126",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0217",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "312b831360f59f7026100258a63c874e.bam",
+            "fileSize": 97074680728,
+            "fileType": "BAM",
+            "fileMd5sum": "312b831360f59f7026100258a63c874e",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "97e0bc54-6396-4ffc-9b32-e1a4f9c05739",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "312b831360f59f7026100258a63c874e.bam",
+            "file_r2": "312b831360f59f7026100258a63c874e.bam",
+            "insert_size": 395,
+            "platform_unit": "QCMG:20131205031023502_8065126",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131205031023502",
+            "submitter_read_group_id": "QCMG:20131205031023502_8065126"
+        },
+        {
+            "file_r1": "312b831360f59f7026100258a63c874e.bam",
+            "file_r2": "312b831360f59f7026100258a63c874e.bam",
+            "insert_size": 395,
+            "platform_unit": "QCMG:20131205034752550_8065126",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131205034752550",
+            "submitter_read_group_id": "QCMG:20131205034752550_8065126"
+        },
+        {
+            "file_r1": "312b831360f59f7026100258a63c874e.bam",
+            "file_r2": "312b831360f59f7026100258a63c874e.bam",
+            "insert_size": 395,
+            "platform_unit": "QCMG:20131205112229103_8065126",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131205112229103",
+            "submitter_read_group_id": "QCMG:20131205112229103_8065126"
+        },
+        {
+            "file_r1": "312b831360f59f7026100258a63c874e.bam",
+            "file_r2": "312b831360f59f7026100258a63c874e.bam",
+            "insert_size": 396,
+            "platform_unit": "QCMG:20131205115944939_8065126",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131205115944939",
+            "submitter_read_group_id": "QCMG:20131205115944939_8065126"
+        },
+        {
+            "file_r1": "312b831360f59f7026100258a63c874e.bam",
+            "file_r2": "312b831360f59f7026100258a63c874e.bam",
+            "insert_size": 396,
+            "platform_unit": "QCMG:20131205120255198_8065126",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131205120255198",
+            "submitter_read_group_id": "QCMG:20131205120255198_8065126"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-129",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/98a7d45a-64de-4237-9592-7289abc8a23b.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/98a7d45a-64de-4237-9592-7289abc8a23b.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8043977",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8043977",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0141",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "63854b51659b5d432754a8e82cb68caa.bam",
+            "fileSize": 98467271331,
+            "fileType": "BAM",
+            "fileMd5sum": "63854b51659b5d432754a8e82cb68caa",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "98a7d45a-64de-4237-9592-7289abc8a23b",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "63854b51659b5d432754a8e82cb68caa.bam",
+            "file_r2": "63854b51659b5d432754a8e82cb68caa.bam",
+            "insert_size": 295,
+            "platform_unit": "QCMG:20120929065235421_8043977",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20120829_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20120929065235421",
+            "submitter_read_group_id": "QCMG:20120929065235421_8043977"
+        },
+        {
+            "file_r1": "63854b51659b5d432754a8e82cb68caa.bam",
+            "file_r2": "63854b51659b5d432754a8e82cb68caa.bam",
+            "insert_size": 294,
+            "platform_unit": "QCMG:20120929085818130_8043977",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20120829_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20120929085818130",
+            "submitter_read_group_id": "QCMG:20120929085818130_8043977"
+        },
+        {
+            "file_r1": "63854b51659b5d432754a8e82cb68caa.bam",
+            "file_r2": "63854b51659b5d432754a8e82cb68caa.bam",
+            "insert_size": 294,
+            "platform_unit": "QCMG:20120929094615446_8043977",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20120829_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20120929094615446",
+            "submitter_read_group_id": "QCMG:20120929094615446_8043977"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-140",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/9d59b3a8-9162-406c-8a35-4a38d15c913b.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/9d59b3a8-9162-406c-8a35-4a38d15c913b.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8069060",
+            "matchedNormalSubmitterSampleId": "8069326",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8069060",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0507",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "59eba01ec683eff717e62b7b11f931b3.bam",
+            "fileSize": 165105298132,
+            "fileType": "BAM",
+            "fileMd5sum": "59eba01ec683eff717e62b7b11f931b3",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "9d59b3a8-9162-406c-8a35-4a38d15c913b",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "59eba01ec683eff717e62b7b11f931b3.bam",
+            "file_r2": "59eba01ec683eff717e62b7b11f931b3.bam",
+            "insert_size": 306,
+            "platform_unit": "QCMG:20140214232703811_8069060",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_L",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232703811",
+            "submitter_read_group_id": "QCMG:20140214232703811_8069060"
+        },
+        {
+            "file_r1": "59eba01ec683eff717e62b7b11f931b3.bam",
+            "file_r2": "59eba01ec683eff717e62b7b11f931b3.bam",
+            "insert_size": 306,
+            "platform_unit": "QCMG:20140214232704623_8069060",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_L",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232704623",
+            "submitter_read_group_id": "QCMG:20140214232704623_8069060"
+        },
+        {
+            "file_r1": "59eba01ec683eff717e62b7b11f931b3.bam",
+            "file_r2": "59eba01ec683eff717e62b7b11f931b3.bam",
+            "insert_size": 306,
+            "platform_unit": "QCMG:20140214232705568_8069060",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_L",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232705568",
+            "submitter_read_group_id": "QCMG:20140214232705568_8069060"
+        },
+        {
+            "file_r1": "59eba01ec683eff717e62b7b11f931b3.bam",
+            "file_r2": "59eba01ec683eff717e62b7b11f931b3.bam",
+            "insert_size": 306,
+            "platform_unit": "QCMG:20140214232706780_8069060",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_L",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232706780",
+            "submitter_read_group_id": "QCMG:20140214232706780_8069060"
+        },
+        {
+            "file_r1": "59eba01ec683eff717e62b7b11f931b3.bam",
+            "file_r2": "59eba01ec683eff717e62b7b11f931b3.bam",
+            "insert_size": 306,
+            "platform_unit": "QCMG:20140214232707041_8069060",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_L",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232707041",
+            "submitter_read_group_id": "QCMG:20140214232707041_8069060"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-183",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/9ea1a6fa-fb82-4301-9025-368416c6e27a.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/9ea1a6fa-fb82-4301-9025-368416c6e27a.json
@@ -1,0 +1,101 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031550",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031550",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0206",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "39f2961982902b54eaed1ac3dd0e0e9c.bam",
+            "fileSize": 102343958818,
+            "fileType": "BAM",
+            "fileMd5sum": "39f2961982902b54eaed1ac3dd0e0e9c",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "9ea1a6fa-fb82-4301-9025-368416c6e27a",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "39f2961982902b54eaed1ac3dd0e0e9c.bam",
+            "file_r2": "39f2961982902b54eaed1ac3dd0e0e9c.bam",
+            "insert_size": 297,
+            "platform_unit": "QCMG:201302151004061_8031550",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4937A1AR24",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:201302151004061",
+            "submitter_read_group_id": "QCMG:201302151004061_8031550"
+        },
+        {
+            "file_r1": "39f2961982902b54eaed1ac3dd0e0e9c.bam",
+            "file_r2": "39f2961982902b54eaed1ac3dd0e0e9c.bam",
+            "insert_size": 295,
+            "platform_unit": "QCMG:20130215111730230_8031550",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4937A1AR24",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130215111730230",
+            "submitter_read_group_id": "QCMG:20130215111730230_8031550"
+        },
+        {
+            "file_r1": "39f2961982902b54eaed1ac3dd0e0e9c.bam",
+            "file_r2": "39f2961982902b54eaed1ac3dd0e0e9c.bam",
+            "insert_size": 295,
+            "platform_unit": "QCMG:20130215111857675_8031550",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4937A1AR24",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130215111857675",
+            "submitter_read_group_id": "QCMG:20130215111857675_8031550"
+        },
+        {
+            "file_r1": "39f2961982902b54eaed1ac3dd0e0e9c.bam",
+            "file_r2": "39f2961982902b54eaed1ac3dd0e0e9c.bam",
+            "insert_size": 295,
+            "platform_unit": "QCMG:20130215113109249_8031550",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4937A1AR24",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130215113109249",
+            "submitter_read_group_id": "QCMG:20130215113109249_8031550"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-161",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 4
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/a88b22a5-1650-4a0f-938f-b37655147b5c.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/a88b22a5-1650-4a0f-938f-b37655147b5c.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8051975",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8051975",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0214",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "41e002bf64ee608a5ccbb932243f13cf.bam",
+            "fileSize": 89096095902,
+            "fileType": "BAM",
+            "fileMd5sum": "41e002bf64ee608a5ccbb932243f13cf",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "a88b22a5-1650-4a0f-938f-b37655147b5c",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "41e002bf64ee608a5ccbb932243f13cf.bam",
+            "file_r2": "41e002bf64ee608a5ccbb932243f13cf.bam",
+            "insert_size": 398,
+            "platform_unit": "QCMG:20130416033032124_8051975",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_W",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416033032124",
+            "submitter_read_group_id": "QCMG:20130416033032124_8051975"
+        },
+        {
+            "file_r1": "41e002bf64ee608a5ccbb932243f13cf.bam",
+            "file_r2": "41e002bf64ee608a5ccbb932243f13cf.bam",
+            "insert_size": 397,
+            "platform_unit": "QCMG:20130416123157727_8051975",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_W",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416123157727",
+            "submitter_read_group_id": "QCMG:20130416123157727_8051975"
+        },
+        {
+            "file_r1": "41e002bf64ee608a5ccbb932243f13cf.bam",
+            "file_r2": "41e002bf64ee608a5ccbb932243f13cf.bam",
+            "insert_size": 397,
+            "platform_unit": "QCMG:20130416125756658_8051975",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_W",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416125756658",
+            "submitter_read_group_id": "QCMG:20130416125756658_8051975"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-148",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/ab895d5a-a530-4876-b7a7-4c83ddbe5548.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/ab895d5a-a530-4876-b7a7-4c83ddbe5548.json
@@ -1,0 +1,75 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8053108",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8053108",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0230",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "378d90760abeba9df1fa259d3af11c8a.bam",
+            "fileSize": 61304859113,
+            "fileType": "BAM",
+            "fileMd5sum": "378d90760abeba9df1fa259d3af11c8a",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "ab895d5a-a530-4876-b7a7-4c83ddbe5548",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "378d90760abeba9df1fa259d3af11c8a.bam",
+            "file_r2": "378d90760abeba9df1fa259d3af11c8a.bam",
+            "insert_size": 321,
+            "platform_unit": "QCMG:20140214232749806_8053108",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_Z",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232749806",
+            "submitter_read_group_id": "QCMG:20140214232749806_8053108"
+        },
+        {
+            "file_r1": "378d90760abeba9df1fa259d3af11c8a.bam",
+            "file_r2": "378d90760abeba9df1fa259d3af11c8a.bam",
+            "insert_size": 321,
+            "platform_unit": "QCMG:20140214232750342_8053108",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_Z",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232750342",
+            "submitter_read_group_id": "QCMG:20140214232750342_8053108"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-154",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 2
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/ac68b6d8-d2c2-4ec1-821a-0c60dff317d9.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/ac68b6d8-d2c2-4ec1-821a-0c60dff317d9.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031686",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031686",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0066",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "a1af62e2e17d86f6dca2be6b8da17d22.bam",
+            "fileSize": 66306296044,
+            "fileType": "BAM",
+            "fileMd5sum": "a1af62e2e17d86f6dca2be6b8da17d22",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "ac68b6d8-d2c2-4ec1-821a-0c60dff317d9",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "a1af62e2e17d86f6dca2be6b8da17d22.bam",
+            "file_r2": "a1af62e2e17d86f6dca2be6b8da17d22.bam",
+            "insert_size": 377,
+            "platform_unit": "QCMG:20130725034057186_8031686",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130514_U",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130725034057186",
+            "submitter_read_group_id": "QCMG:20130725034057186_8031686"
+        },
+        {
+            "file_r1": "a1af62e2e17d86f6dca2be6b8da17d22.bam",
+            "file_r2": "a1af62e2e17d86f6dca2be6b8da17d22.bam",
+            "insert_size": 377,
+            "platform_unit": "QCMG:20130725034359213_8031686",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130514_U",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130725034359213",
+            "submitter_read_group_id": "QCMG:20130725034359213_8031686"
+        },
+        {
+            "file_r1": "a1af62e2e17d86f6dca2be6b8da17d22.bam",
+            "file_r2": "a1af62e2e17d86f6dca2be6b8da17d22.bam",
+            "insert_size": 377,
+            "platform_unit": "QCMG:20130725053904645_8031686",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130514_U",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130725053904645",
+            "submitter_read_group_id": "QCMG:20130725053904645_8031686"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-123",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/b210266f-a7a2-4abb-a557-f75481a46449.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/b210266f-a7a2-4abb-a557-f75481a46449.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8061188",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8061188",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0326",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "d4919aff5d5871793f37335a8fa6ca14.bam",
+            "fileSize": 69966510238,
+            "fileType": "BAM",
+            "fileMd5sum": "d4919aff5d5871793f37335a8fa6ca14",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "b210266f-a7a2-4abb-a557-f75481a46449",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "d4919aff5d5871793f37335a8fa6ca14.bam",
+            "file_r2": "d4919aff5d5871793f37335a8fa6ca14.bam",
+            "insert_size": 376,
+            "platform_unit": "QCMG:2013092402002421_8061188",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_L",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013092402002421",
+            "submitter_read_group_id": "QCMG:2013092402002421_8061188"
+        },
+        {
+            "file_r1": "d4919aff5d5871793f37335a8fa6ca14.bam",
+            "file_r2": "d4919aff5d5871793f37335a8fa6ca14.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:20130924032712666_8061188",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_L",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130924032712666",
+            "submitter_read_group_id": "QCMG:20130924032712666_8061188"
+        },
+        {
+            "file_r1": "d4919aff5d5871793f37335a8fa6ca14.bam",
+            "file_r2": "d4919aff5d5871793f37335a8fa6ca14.bam",
+            "insert_size": 377,
+            "platform_unit": "QCMG:20130924045231302_8061188",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_L",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130924045231302",
+            "submitter_read_group_id": "QCMG:20130924045231302_8061188"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-185",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/b2dea080-f343-4799-9ac2-5fb693fc1697.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/b2dea080-f343-4799-9ac2-5fb693fc1697.json
@@ -1,0 +1,101 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031562",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031562",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0205",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "e2e8001a97e65f03760caccc3481ec52.bam",
+            "fileSize": 143567132697,
+            "fileType": "BAM",
+            "fileMd5sum": "e2e8001a97e65f03760caccc3481ec52",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "b2dea080-f343-4799-9ac2-5fb693fc1697",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "e2e8001a97e65f03760caccc3481ec52.bam",
+            "file_r2": "e2e8001a97e65f03760caccc3481ec52.bam",
+            "insert_size": 296,
+            "platform_unit": "QCMG:20130308102654979_8031562",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4936A1AR22",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130308102654979",
+            "submitter_read_group_id": "QCMG:20130308102654979_8031562"
+        },
+        {
+            "file_r1": "e2e8001a97e65f03760caccc3481ec52.bam",
+            "file_r2": "e2e8001a97e65f03760caccc3481ec52.bam",
+            "insert_size": 299,
+            "platform_unit": "QCMG:20130308113053715_8031562",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4936A1AR22",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130308113053715",
+            "submitter_read_group_id": "QCMG:20130308113053715_8031562"
+        },
+        {
+            "file_r1": "e2e8001a97e65f03760caccc3481ec52.bam",
+            "file_r2": "e2e8001a97e65f03760caccc3481ec52.bam",
+            "insert_size": 298,
+            "platform_unit": "QCMG:20130308120715878_8031562",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4936A1AR22",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130308120715878",
+            "submitter_read_group_id": "QCMG:20130308120715878_8031562"
+        },
+        {
+            "file_r1": "e2e8001a97e65f03760caccc3481ec52.bam",
+            "file_r2": "e2e8001a97e65f03760caccc3481ec52.bam",
+            "insert_size": 298,
+            "platform_unit": "QCMG:20130309015838206_8031562",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4936A1AR22",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309015838206",
+            "submitter_read_group_id": "QCMG:20130309015838206_8031562"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-120",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 4
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/b5267295-6a93-4acb-9326-c38d0f66c41e.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/b5267295-6a93-4acb-9326-c38d0f66c41e.json
@@ -1,0 +1,75 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8069455",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8069455",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0526",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "61aa1f5ff9c6b6ee7ac1c90b2e3a408b.bam",
+            "fileSize": 61329358437,
+            "fileType": "BAM",
+            "fileMd5sum": "61aa1f5ff9c6b6ee7ac1c90b2e3a408b",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "b5267295-6a93-4acb-9326-c38d0f66c41e",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "61aa1f5ff9c6b6ee7ac1c90b2e3a408b.bam",
+            "file_r2": "61aa1f5ff9c6b6ee7ac1c90b2e3a408b.bam",
+            "insert_size": 316,
+            "platform_unit": "QCMG:20140214232623050_8069455",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232623050",
+            "submitter_read_group_id": "QCMG:20140214232623050_8069455"
+        },
+        {
+            "file_r1": "61aa1f5ff9c6b6ee7ac1c90b2e3a408b.bam",
+            "file_r2": "61aa1f5ff9c6b6ee7ac1c90b2e3a408b.bam",
+            "insert_size": 316,
+            "platform_unit": "QCMG:20140214232624114_8069455",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232624114",
+            "submitter_read_group_id": "QCMG:20140214232624114_8069455"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-190",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 2
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/b5a0e3ec-42da-4449-945b-70286b75dcca.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/b5a0e3ec-42da-4449-945b-70286b75dcca.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8015265",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8015265",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0053",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "89dbd1fbd83ea550fbe5213c2ae89bd5.bam",
+            "fileSize": 58077955625,
+            "fileType": "BAM",
+            "fileMd5sum": "89dbd1fbd83ea550fbe5213c2ae89bd5",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "b5a0e3ec-42da-4449-945b-70286b75dcca",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "89dbd1fbd83ea550fbe5213c2ae89bd5.bam",
+            "file_r2": "89dbd1fbd83ea550fbe5213c2ae89bd5.bam",
+            "insert_size": 370,
+            "platform_unit": "QCMG:20130924015709404_8015265",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130827_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130924015709404",
+            "submitter_read_group_id": "QCMG:20130924015709404_8015265"
+        },
+        {
+            "file_r1": "89dbd1fbd83ea550fbe5213c2ae89bd5.bam",
+            "file_r2": "89dbd1fbd83ea550fbe5213c2ae89bd5.bam",
+            "insert_size": 371,
+            "platform_unit": "QCMG:20130924110648348_8015265",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130827_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130924110648348",
+            "submitter_read_group_id": "QCMG:20130924110648348_8015265"
+        },
+        {
+            "file_r1": "89dbd1fbd83ea550fbe5213c2ae89bd5.bam",
+            "file_r2": "89dbd1fbd83ea550fbe5213c2ae89bd5.bam",
+            "insert_size": 371,
+            "platform_unit": "QCMG:20130924115332380_8015265",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130827_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130924115332380",
+            "submitter_read_group_id": "QCMG:20130924115332380_8015265"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-127",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/b6aae215-bd81-4eec-b0f8-6331127f1503.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/b6aae215-bd81-4eec-b0f8-6331127f1503.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057487",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057487",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0224",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "ebaa7a2e36e2175b910865e005034a11.bam",
+            "fileSize": 46908937988,
+            "fileType": "BAM",
+            "fileMd5sum": "ebaa7a2e36e2175b910865e005034a11",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "b6aae215-bd81-4eec-b0f8-6331127f1503",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "ebaa7a2e36e2175b910865e005034a11.bam",
+            "file_r2": "ebaa7a2e36e2175b910865e005034a11.bam",
+            "insert_size": 418,
+            "platform_unit": "QCMG:20140211053708299_8057487",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20140124_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140211053708299",
+            "submitter_read_group_id": "QCMG:20140211053708299_8057487"
+        },
+        {
+            "file_r1": "ebaa7a2e36e2175b910865e005034a11.bam",
+            "file_r2": "ebaa7a2e36e2175b910865e005034a11.bam",
+            "insert_size": 418,
+            "platform_unit": "QCMG:20140211082636727_8057487",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20140124_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140211082636727",
+            "submitter_read_group_id": "QCMG:20140211082636727_8057487"
+        },
+        {
+            "file_r1": "ebaa7a2e36e2175b910865e005034a11.bam",
+            "file_r2": "ebaa7a2e36e2175b910865e005034a11.bam",
+            "insert_size": 418,
+            "platform_unit": "QCMG:20140211085238737_8057487",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20140124_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140211085238737",
+            "submitter_read_group_id": "QCMG:20140211085238737_8057487"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-102",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/b73a8567-a21c-4200-b219-dc366ec7433c.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/b73a8567-a21c-4200-b219-dc366ec7433c.json
@@ -1,0 +1,127 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8044436",
+            "matchedNormalSubmitterSampleId": "8044442",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8044436",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0149",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "fileSize": 234378647876,
+            "fileType": "BAM",
+            "fileMd5sum": "c2ea1e16a58e975c8d4d2ba49df888e0",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "b73a8567-a21c-4200-b219-dc366ec7433c",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "file_r2": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "insert_size": 293,
+            "platform_unit": "QCMG:20130211014034895_8044436",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5455A2AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130211014034895",
+            "submitter_read_group_id": "QCMG:20130211014034895_8044436"
+        },
+        {
+            "file_r1": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "file_r2": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "insert_size": 293,
+            "platform_unit": "QCMG:20130211014729791_8044436",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5455A2AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130211014729791",
+            "submitter_read_group_id": "QCMG:20130211014729791_8044436"
+        },
+        {
+            "file_r1": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "file_r2": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "insert_size": 293,
+            "platform_unit": "QCMG:20130211032814876_8044436",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5455A2AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130211032814876",
+            "submitter_read_group_id": "QCMG:20130211032814876_8044436"
+        },
+        {
+            "file_r1": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "file_r2": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "insert_size": 293,
+            "platform_unit": "QCMG:20130211033044375_8044436",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5455A2AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130211033044375",
+            "submitter_read_group_id": "QCMG:20130211033044375_8044436"
+        },
+        {
+            "file_r1": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "file_r2": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "insert_size": 293,
+            "platform_unit": "QCMG:20130211042236775_8044436",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5455A2AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130211042236775",
+            "submitter_read_group_id": "QCMG:20130211042236775_8044436"
+        },
+        {
+            "file_r1": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "file_r2": "c2ea1e16a58e975c8d4d2ba49df888e0.bam",
+            "insert_size": 293,
+            "platform_unit": "QCMG:2013021104525140_8044436",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5455A2AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013021104525140",
+            "submitter_read_group_id": "QCMG:2013021104525140_8044436"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-155",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 6
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/bdfd5ad9-c4e5-423d-ac10-8103370008da.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/bdfd5ad9-c4e5-423d-ac10-8103370008da.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057484",
+            "matchedNormalSubmitterSampleId": "8049112",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057484",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0223",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "ac570307b3acc0cdc0a250cd1f13ada2.bam",
+            "fileSize": 140014430894,
+            "fileType": "BAM",
+            "fileMd5sum": "ac570307b3acc0cdc0a250cd1f13ada2",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "bdfd5ad9-c4e5-423d-ac10-8103370008da",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "ac570307b3acc0cdc0a250cd1f13ada2.bam",
+            "file_r2": "ac570307b3acc0cdc0a250cd1f13ada2.bam",
+            "insert_size": 398,
+            "platform_unit": "QCMG:20130416021131531_8057484",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416021131531",
+            "submitter_read_group_id": "QCMG:20130416021131531_8057484"
+        },
+        {
+            "file_r1": "ac570307b3acc0cdc0a250cd1f13ada2.bam",
+            "file_r2": "ac570307b3acc0cdc0a250cd1f13ada2.bam",
+            "insert_size": 397,
+            "platform_unit": "QCMG:20130416025541141_8057484",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416025541141",
+            "submitter_read_group_id": "QCMG:20130416025541141_8057484"
+        },
+        {
+            "file_r1": "ac570307b3acc0cdc0a250cd1f13ada2.bam",
+            "file_r2": "ac570307b3acc0cdc0a250cd1f13ada2.bam",
+            "insert_size": 395,
+            "platform_unit": "QCMG:20130416040631230_8057484",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416040631230",
+            "submitter_read_group_id": "QCMG:20130416040631230_8057484"
+        },
+        {
+            "file_r1": "ac570307b3acc0cdc0a250cd1f13ada2.bam",
+            "file_r2": "ac570307b3acc0cdc0a250cd1f13ada2.bam",
+            "insert_size": 395,
+            "platform_unit": "QCMG:20130416042559555_8057484",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416042559555",
+            "submitter_read_group_id": "QCMG:20130416042559555_8057484"
+        },
+        {
+            "file_r1": "ac570307b3acc0cdc0a250cd1f13ada2.bam",
+            "file_r2": "ac570307b3acc0cdc0a250cd1f13ada2.bam",
+            "insert_size": 397,
+            "platform_unit": "QCMG:20130416113205342_8057484",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416113205342",
+            "submitter_read_group_id": "QCMG:20130416113205342_8057484"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-119",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/bed4a712-7221-4150-8a29-7c81bd03a078.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/bed4a712-7221-4150-8a29-7c81bd03a078.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8012203",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8012203",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0007",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "b2423ff84ae7ae60a0f20f583955c42b.bam",
+            "fileSize": 111844151555,
+            "fileType": "BAM",
+            "fileMd5sum": "b2423ff84ae7ae60a0f20f583955c42b",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "bed4a712-7221-4150-8a29-7c81bd03a078",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "b2423ff84ae7ae60a0f20f583955c42b.bam",
+            "file_r2": "b2423ff84ae7ae60a0f20f583955c42b.bam",
+            "insert_size": 339,
+            "platform_unit": "QCMG:20121121053625245_8012203",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121106_B",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20121121053625245",
+            "submitter_read_group_id": "QCMG:20121121053625245_8012203"
+        },
+        {
+            "file_r1": "b2423ff84ae7ae60a0f20f583955c42b.bam",
+            "file_r2": "b2423ff84ae7ae60a0f20f583955c42b.bam",
+            "insert_size": 339,
+            "platform_unit": "QCMG:20121122120824524_8012203",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121106_B",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20121122120824524",
+            "submitter_read_group_id": "QCMG:20121122120824524_8012203"
+        },
+        {
+            "file_r1": "b2423ff84ae7ae60a0f20f583955c42b.bam",
+            "file_r2": "b2423ff84ae7ae60a0f20f583955c42b.bam",
+            "insert_size": 340,
+            "platform_unit": "QCMG:20121128110718217_8012203",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121106_B",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20121128110718217",
+            "submitter_read_group_id": "QCMG:20121128110718217_8012203"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-109",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/bfd7b491-9d95-4eaf-a5c4-1877513a7cd3.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/bfd7b491-9d95-4eaf-a5c4-1877513a7cd3.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8061105",
+            "matchedNormalSubmitterSampleId": "8061188",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8061105",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0326",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "61d3cfbc9682be8a8b771fc184b13bfc.bam",
+            "fileSize": 116931915265,
+            "fileType": "BAM",
+            "fileMd5sum": "61d3cfbc9682be8a8b771fc184b13bfc",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "bfd7b491-9d95-4eaf-a5c4-1877513a7cd3",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "61d3cfbc9682be8a8b771fc184b13bfc.bam",
+            "file_r2": "61d3cfbc9682be8a8b771fc184b13bfc.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:2013092402330751_8061105",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013092402330751",
+            "submitter_read_group_id": "QCMG:2013092402330751_8061105"
+        },
+        {
+            "file_r1": "61d3cfbc9682be8a8b771fc184b13bfc.bam",
+            "file_r2": "61d3cfbc9682be8a8b771fc184b13bfc.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:2013092403024173_8061105",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013092403024173",
+            "submitter_read_group_id": "QCMG:2013092403024173_8061105"
+        },
+        {
+            "file_r1": "61d3cfbc9682be8a8b771fc184b13bfc.bam",
+            "file_r2": "61d3cfbc9682be8a8b771fc184b13bfc.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:20130924040400498_8061105",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130924040400498",
+            "submitter_read_group_id": "QCMG:20130924040400498_8061105"
+        },
+        {
+            "file_r1": "61d3cfbc9682be8a8b771fc184b13bfc.bam",
+            "file_r2": "61d3cfbc9682be8a8b771fc184b13bfc.bam",
+            "insert_size": 379,
+            "platform_unit": "QCMG:2013092411582883_8061105",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013092411582883",
+            "submitter_read_group_id": "QCMG:2013092411582883_8061105"
+        },
+        {
+            "file_r1": "61d3cfbc9682be8a8b771fc184b13bfc.bam",
+            "file_r2": "61d3cfbc9682be8a8b771fc184b13bfc.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:20130925124658794_8061105",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130925124658794",
+            "submitter_read_group_id": "QCMG:20130925124658794_8061105"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-168",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/c3ae8b6d-861e-4f52-acd4-004b4e6fb732.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/c3ae8b6d-861e-4f52-acd4-004b4e6fb732.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057709",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057709",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0315",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "2f7be224a43b1dd9bd41d486db2d65ba.bam",
+            "fileSize": 79035002593,
+            "fileType": "BAM",
+            "fileMd5sum": "2f7be224a43b1dd9bd41d486db2d65ba",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "c3ae8b6d-861e-4f52-acd4-004b4e6fb732",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "2f7be224a43b1dd9bd41d486db2d65ba.bam",
+            "file_r2": "2f7be224a43b1dd9bd41d486db2d65ba.bam",
+            "insert_size": 380,
+            "platform_unit": "QCMG:20130424013041289_8057709",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_L",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130424013041289",
+            "submitter_read_group_id": "QCMG:20130424013041289_8057709"
+        },
+        {
+            "file_r1": "2f7be224a43b1dd9bd41d486db2d65ba.bam",
+            "file_r2": "2f7be224a43b1dd9bd41d486db2d65ba.bam",
+            "insert_size": 379,
+            "platform_unit": "QCMG:201304240134492_8057709",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_L",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:201304240134492",
+            "submitter_read_group_id": "QCMG:201304240134492_8057709"
+        },
+        {
+            "file_r1": "2f7be224a43b1dd9bd41d486db2d65ba.bam",
+            "file_r2": "2f7be224a43b1dd9bd41d486db2d65ba.bam",
+            "insert_size": 380,
+            "platform_unit": "QCMG:20130424020327614_8057709",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130404_L",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130424020327614",
+            "submitter_read_group_id": "QCMG:20130424020327614_8057709"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-145",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/c9049f73-96f1-4c2f-8dc5-3a5d9a853d8a.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/c9049f73-96f1-4c2f-8dc5-3a5d9a853d8a.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8057629",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8057629",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0227",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "790bb5b65b0cdff7543ebda00dc19410.bam",
+            "fileSize": 85390260305,
+            "fileType": "BAM",
+            "fileMd5sum": "790bb5b65b0cdff7543ebda00dc19410",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "c9049f73-96f1-4c2f-8dc5-3a5d9a853d8a",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "790bb5b65b0cdff7543ebda00dc19410.bam",
+            "file_r2": "790bb5b65b0cdff7543ebda00dc19410.bam",
+            "insert_size": 322,
+            "platform_unit": "QCMG:20140214232614872_8057629",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AJ",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232614872",
+            "submitter_read_group_id": "QCMG:20140214232614872_8057629"
+        },
+        {
+            "file_r1": "790bb5b65b0cdff7543ebda00dc19410.bam",
+            "file_r2": "790bb5b65b0cdff7543ebda00dc19410.bam",
+            "insert_size": 322,
+            "platform_unit": "QCMG:20140214232615615_8057629",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AJ",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232615615",
+            "submitter_read_group_id": "QCMG:20140214232615615_8057629"
+        },
+        {
+            "file_r1": "790bb5b65b0cdff7543ebda00dc19410.bam",
+            "file_r2": "790bb5b65b0cdff7543ebda00dc19410.bam",
+            "insert_size": 321,
+            "platform_unit": "QCMG:20140214232753462_8057629",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AJ",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232753462",
+            "submitter_read_group_id": "QCMG:20140214232753462_8057629"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-163",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/cd3fbc04-0e75-41d6-a424-b33d46a1b2dd.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/cd3fbc04-0e75-41d6-a424-b33d46a1b2dd.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8067938",
+            "matchedNormalSubmitterSampleId": "8058183",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8067938",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0313",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "b020cf8e8f632f60fdf0f785645b7bcb.bam",
+            "fileSize": 147388226010,
+            "fileType": "BAM",
+            "fileMd5sum": "b020cf8e8f632f60fdf0f785645b7bcb",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "cd3fbc04-0e75-41d6-a424-b33d46a1b2dd",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "b020cf8e8f632f60fdf0f785645b7bcb.bam",
+            "file_r2": "b020cf8e8f632f60fdf0f785645b7bcb.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140214232626881_8067938",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232626881",
+            "submitter_read_group_id": "QCMG:20140214232626881_8067938"
+        },
+        {
+            "file_r1": "b020cf8e8f632f60fdf0f785645b7bcb.bam",
+            "file_r2": "b020cf8e8f632f60fdf0f785645b7bcb.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140214232627728_8067938",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232627728",
+            "submitter_read_group_id": "QCMG:20140214232627728_8067938"
+        },
+        {
+            "file_r1": "b020cf8e8f632f60fdf0f785645b7bcb.bam",
+            "file_r2": "b020cf8e8f632f60fdf0f785645b7bcb.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140214232628618_8067938",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232628618",
+            "submitter_read_group_id": "QCMG:20140214232628618_8067938"
+        },
+        {
+            "file_r1": "b020cf8e8f632f60fdf0f785645b7bcb.bam",
+            "file_r2": "b020cf8e8f632f60fdf0f785645b7bcb.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140214232629800_8067938",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232629800",
+            "submitter_read_group_id": "QCMG:20140214232629800_8067938"
+        },
+        {
+            "file_r1": "b020cf8e8f632f60fdf0f785645b7bcb.bam",
+            "file_r2": "b020cf8e8f632f60fdf0f785645b7bcb.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140214232630407_8067938",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_F",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232630407",
+            "submitter_read_group_id": "QCMG:20140214232630407_8067938"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-101",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/d28cfce4-8819-4db5-9a69-1a483ed40bbe.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/d28cfce4-8819-4db5-9a69-1a483ed40bbe.json
@@ -1,0 +1,101 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8044430",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8044430",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0153",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "f7a5e47e2770f809417b5f82f406940f.bam",
+            "fileSize": 146944071044,
+            "fileType": "BAM",
+            "fileMd5sum": "f7a5e47e2770f809417b5f82f406940f",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "d28cfce4-8819-4db5-9a69-1a483ed40bbe",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "f7a5e47e2770f809417b5f82f406940f.bam",
+            "file_r2": "f7a5e47e2770f809417b5f82f406940f.bam",
+            "insert_size": 342,
+            "platform_unit": "QCMG:20130309100435851_8044430",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5456A1AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309100435851",
+            "submitter_read_group_id": "QCMG:20130309100435851_8044430"
+        },
+        {
+            "file_r1": "f7a5e47e2770f809417b5f82f406940f.bam",
+            "file_r2": "f7a5e47e2770f809417b5f82f406940f.bam",
+            "insert_size": 340,
+            "platform_unit": "QCMG:20130309105146709_8044430",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5456A1AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309105146709",
+            "submitter_read_group_id": "QCMG:20130309105146709_8044430"
+        },
+        {
+            "file_r1": "f7a5e47e2770f809417b5f82f406940f.bam",
+            "file_r2": "f7a5e47e2770f809417b5f82f406940f.bam",
+            "insert_size": 341,
+            "platform_unit": "QCMG:2013030911550087_8044430",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5456A1AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013030911550087",
+            "submitter_read_group_id": "QCMG:2013030911550087_8044430"
+        },
+        {
+            "file_r1": "f7a5e47e2770f809417b5f82f406940f.bam",
+            "file_r2": "f7a5e47e2770f809417b5f82f406940f.bam",
+            "insert_size": 340,
+            "platform_unit": "QCMG:20130309115911784_8044430",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5456A1AR2",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130309115911784",
+            "submitter_read_group_id": "QCMG:20130309115911784_8044430"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-114",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 4
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/d3b3295b-2518-4c13-9703-420a3632d0d7.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/d3b3295b-2518-4c13-9703-420a3632d0d7.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8069120",
+            "matchedNormalSubmitterSampleId": "8069439",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8069120",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0518",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "d65eee66ecfacf55670339827f870add.bam",
+            "fileSize": 159804515929,
+            "fileType": "BAM",
+            "fileMd5sum": "d65eee66ecfacf55670339827f870add",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "d3b3295b-2518-4c13-9703-420a3632d0d7",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "d65eee66ecfacf55670339827f870add.bam",
+            "file_r2": "d65eee66ecfacf55670339827f870add.bam",
+            "insert_size": 301,
+            "platform_unit": "QCMG:20140214232832452_8069120",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AP",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232832452",
+            "submitter_read_group_id": "QCMG:20140214232832452_8069120"
+        },
+        {
+            "file_r1": "d65eee66ecfacf55670339827f870add.bam",
+            "file_r2": "d65eee66ecfacf55670339827f870add.bam",
+            "insert_size": 301,
+            "platform_unit": "QCMG:20140214232833788_8069120",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AP",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232833788",
+            "submitter_read_group_id": "QCMG:20140214232833788_8069120"
+        },
+        {
+            "file_r1": "d65eee66ecfacf55670339827f870add.bam",
+            "file_r2": "d65eee66ecfacf55670339827f870add.bam",
+            "insert_size": 303,
+            "platform_unit": "QCMG:20140214232834784_8069120",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AP",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232834784",
+            "submitter_read_group_id": "QCMG:20140214232834784_8069120"
+        },
+        {
+            "file_r1": "d65eee66ecfacf55670339827f870add.bam",
+            "file_r2": "d65eee66ecfacf55670339827f870add.bam",
+            "insert_size": 301,
+            "platform_unit": "QCMG:20140214232835202_8069120",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AP",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232835202",
+            "submitter_read_group_id": "QCMG:20140214232835202_8069120"
+        },
+        {
+            "file_r1": "d65eee66ecfacf55670339827f870add.bam",
+            "file_r2": "d65eee66ecfacf55670339827f870add.bam",
+            "insert_size": 308,
+            "platform_unit": "QCMG:20140214232836701_8069120",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AP",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232836701",
+            "submitter_read_group_id": "QCMG:20140214232836701_8069120"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-171",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/d663f19c-3dcc-40dc-8a0c-f606f85cf9ff.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/d663f19c-3dcc-40dc-8a0c-f606f85cf9ff.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8049112",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8049112",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0223",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "f98840f5a9d4840ba04417f7d9ff8ea9.bam",
+            "fileSize": 84730616282,
+            "fileType": "BAM",
+            "fileMd5sum": "f98840f5a9d4840ba04417f7d9ff8ea9",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "d663f19c-3dcc-40dc-8a0c-f606f85cf9ff",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "f98840f5a9d4840ba04417f7d9ff8ea9.bam",
+            "file_r2": "f98840f5a9d4840ba04417f7d9ff8ea9.bam",
+            "insert_size": 402,
+            "platform_unit": "QCMG:20130416034419285_8049112",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416034419285",
+            "submitter_read_group_id": "QCMG:20130416034419285_8049112"
+        },
+        {
+            "file_r1": "f98840f5a9d4840ba04417f7d9ff8ea9.bam",
+            "file_r2": "f98840f5a9d4840ba04417f7d9ff8ea9.bam",
+            "insert_size": 402,
+            "platform_unit": "QCMG:20130416120630465_8049112",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416120630465",
+            "submitter_read_group_id": "QCMG:20130416120630465_8049112"
+        },
+        {
+            "file_r1": "f98840f5a9d4840ba04417f7d9ff8ea9.bam",
+            "file_r2": "f98840f5a9d4840ba04417f7d9ff8ea9.bam",
+            "insert_size": 402,
+            "platform_unit": "QCMG:20130416122342882_8049112",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130201_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130416122342882",
+            "submitter_read_group_id": "QCMG:20130416122342882_8049112"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-122",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/dc6865db-c0e4-498e-9373-713e86744c6d.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/dc6865db-c0e4-498e-9373-713e86744c6d.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031556",
+            "matchedNormalSubmitterSampleId": "8031562",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031556",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0205",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "282026a8e9f71f31214a50d4f14771ce.bam",
+            "fileSize": 216083154251,
+            "fileType": "BAM",
+            "fileMd5sum": "282026a8e9f71f31214a50d4f14771ce",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "dc6865db-c0e4-498e-9373-713e86744c6d",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "282026a8e9f71f31214a50d4f14771ce.bam",
+            "file_r2": "282026a8e9f71f31214a50d4f14771ce.bam",
+            "insert_size": 292,
+            "platform_unit": "QCMG:20130209113337699_8031556",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4936A2AR21",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130209113337699",
+            "submitter_read_group_id": "QCMG:20130209113337699_8031556"
+        },
+        {
+            "file_r1": "282026a8e9f71f31214a50d4f14771ce.bam",
+            "file_r2": "282026a8e9f71f31214a50d4f14771ce.bam",
+            "insert_size": 292,
+            "platform_unit": "QCMG:20130209115924639_8031556",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4936A2AR21",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130209115924639",
+            "submitter_read_group_id": "QCMG:20130209115924639_8031556"
+        },
+        {
+            "file_r1": "282026a8e9f71f31214a50d4f14771ce.bam",
+            "file_r2": "282026a8e9f71f31214a50d4f14771ce.bam",
+            "insert_size": 292,
+            "platform_unit": "QCMG:2013020912002811_8031556",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4936A2AR21",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013020912002811",
+            "submitter_read_group_id": "QCMG:2013020912002811_8031556"
+        },
+        {
+            "file_r1": "282026a8e9f71f31214a50d4f14771ce.bam",
+            "file_r2": "282026a8e9f71f31214a50d4f14771ce.bam",
+            "insert_size": 292,
+            "platform_unit": "QCMG:20130209120648259_8031556",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4936A2AR21",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130209120648259",
+            "submitter_read_group_id": "QCMG:20130209120648259_8031556"
+        },
+        {
+            "file_r1": "282026a8e9f71f31214a50d4f14771ce.bam",
+            "file_r2": "282026a8e9f71f31214a50d4f14771ce.bam",
+            "insert_size": 292,
+            "platform_unit": "QCMG:20130209121244430_8031556",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4936A2AR21",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130209121244430",
+            "submitter_read_group_id": "QCMG:20130209121244430_8031556"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-118",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e12ddacb-46b4-4a94-812e-d0b52b9f96e3.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e12ddacb-46b4-4a94-812e-d0b52b9f96e3.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8012199",
+            "matchedNormalSubmitterSampleId": "8012203",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8012199",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0007",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "2abf20ce4378c5a1bf3d72dba0b0e1d2.bam",
+            "fileSize": 161687081647,
+            "fileType": "BAM",
+            "fileMd5sum": "2abf20ce4378c5a1bf3d72dba0b0e1d2",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "e12ddacb-46b4-4a94-812e-d0b52b9f96e3",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "2abf20ce4378c5a1bf3d72dba0b0e1d2.bam",
+            "file_r2": "2abf20ce4378c5a1bf3d72dba0b0e1d2.bam",
+            "insert_size": 334,
+            "platform_unit": "QCMG:20121121011220870_8012199",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121106_A",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20121121011220870",
+            "submitter_read_group_id": "QCMG:20121121011220870_8012199"
+        },
+        {
+            "file_r1": "2abf20ce4378c5a1bf3d72dba0b0e1d2.bam",
+            "file_r2": "2abf20ce4378c5a1bf3d72dba0b0e1d2.bam",
+            "insert_size": 333,
+            "platform_unit": "QCMG:20121121011533352_8012199",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121106_A",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20121121011533352",
+            "submitter_read_group_id": "QCMG:20121121011533352_8012199"
+        },
+        {
+            "file_r1": "2abf20ce4378c5a1bf3d72dba0b0e1d2.bam",
+            "file_r2": "2abf20ce4378c5a1bf3d72dba0b0e1d2.bam",
+            "insert_size": 334,
+            "platform_unit": "QCMG:20121121065954222_8012199",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121106_A",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20121121065954222",
+            "submitter_read_group_id": "QCMG:20121121065954222_8012199"
+        },
+        {
+            "file_r1": "2abf20ce4378c5a1bf3d72dba0b0e1d2.bam",
+            "file_r2": "2abf20ce4378c5a1bf3d72dba0b0e1d2.bam",
+            "insert_size": 333,
+            "platform_unit": "QCMG:20121121091953869_8012199",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121106_A",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20121121091953869",
+            "submitter_read_group_id": "QCMG:20121121091953869_8012199"
+        },
+        {
+            "file_r1": "2abf20ce4378c5a1bf3d72dba0b0e1d2.bam",
+            "file_r2": "2abf20ce4378c5a1bf3d72dba0b0e1d2.bam",
+            "insert_size": 334,
+            "platform_unit": "QCMG:20121121113152135_8012199",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20121106_A",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20121121113152135",
+            "submitter_read_group_id": "QCMG:20121121113152135_8012199"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-142",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e1675b2b-c42e-414d-adb3-461945a1ba5f.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e1675b2b-c42e-414d-adb3-461945a1ba5f.json
@@ -1,0 +1,127 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8067507",
+            "matchedNormalSubmitterSampleId": "8031103",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8067507",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0099",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "fileSize": 184971541253,
+            "fileType": "BAM",
+            "fileMd5sum": "8a94e5c678ed9a0e131f0d2453495612",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "e1675b2b-c42e-414d-adb3-461945a1ba5f",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "file_r2": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140124172154577_8067507",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172154577",
+            "submitter_read_group_id": "QCMG:20140124172154577_8067507"
+        },
+        {
+            "file_r1": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "file_r2": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140124172155212_8067507",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172155212",
+            "submitter_read_group_id": "QCMG:20140124172155212_8067507"
+        },
+        {
+            "file_r1": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "file_r2": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140124172156854_8067507",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172156854",
+            "submitter_read_group_id": "QCMG:20140124172156854_8067507"
+        },
+        {
+            "file_r1": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "file_r2": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140124172157331_8067507",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172157331",
+            "submitter_read_group_id": "QCMG:20140124172157331_8067507"
+        },
+        {
+            "file_r1": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "file_r2": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140124172158858_8067507",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172158858",
+            "submitter_read_group_id": "QCMG:20140124172158858_8067507"
+        },
+        {
+            "file_r1": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "file_r2": "8a94e5c678ed9a0e131f0d2453495612.bam",
+            "insert_size": 311,
+            "platform_unit": "QCMG:20140124172216187_8067507",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_M",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172216187",
+            "submitter_read_group_id": "QCMG:20140124172216187_8067507"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-126",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 6
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e51f6df3-9646-4674-988e-c8b38e214c4e.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e51f6df3-9646-4674-988e-c8b38e214c4e.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8058180",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8058180",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0301",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "09d849082cd3bfed8dd97bb67b76f166.bam",
+            "fileSize": 64550878813,
+            "fileType": "BAM",
+            "fileMd5sum": "09d849082cd3bfed8dd97bb67b76f166",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "e51f6df3-9646-4674-988e-c8b38e214c4e",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "09d849082cd3bfed8dd97bb67b76f166.bam",
+            "file_r2": "09d849082cd3bfed8dd97bb67b76f166.bam",
+            "insert_size": 316,
+            "platform_unit": "QCMG:20140124172131760_8058180",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172131760",
+            "submitter_read_group_id": "QCMG:20140124172131760_8058180"
+        },
+        {
+            "file_r1": "09d849082cd3bfed8dd97bb67b76f166.bam",
+            "file_r2": "09d849082cd3bfed8dd97bb67b76f166.bam",
+            "insert_size": 316,
+            "platform_unit": "QCMG:20140124172132541_8058180",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172132541",
+            "submitter_read_group_id": "QCMG:20140124172132541_8058180"
+        },
+        {
+            "file_r1": "09d849082cd3bfed8dd97bb67b76f166.bam",
+            "file_r2": "09d849082cd3bfed8dd97bb67b76f166.bam",
+            "insert_size": 316,
+            "platform_unit": "QCMG:20140124172133631_8058180",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_H",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172133631",
+            "submitter_read_group_id": "QCMG:20140124172133631_8058180"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-157",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e669e101-2800-4c48-b9ce-a533a37fa7d7.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e669e101-2800-4c48-b9ce-a533a37fa7d7.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8013143",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8013143",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0020",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "899c1cf4660f506f4e6592fe7afcdaea.bam",
+            "fileSize": 70502032220,
+            "fileType": "BAM",
+            "fileMd5sum": "899c1cf4660f506f4e6592fe7afcdaea",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "e669e101-2800-4c48-b9ce-a533a37fa7d7",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "899c1cf4660f506f4e6592fe7afcdaea.bam",
+            "file_r2": "899c1cf4660f506f4e6592fe7afcdaea.bam",
+            "insert_size": 318,
+            "platform_unit": "QCMG:20140124172122747_8013143",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_D",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172122747",
+            "submitter_read_group_id": "QCMG:20140124172122747_8013143"
+        },
+        {
+            "file_r1": "899c1cf4660f506f4e6592fe7afcdaea.bam",
+            "file_r2": "899c1cf4660f506f4e6592fe7afcdaea.bam",
+            "insert_size": 318,
+            "platform_unit": "QCMG:20140124172123344_8013143",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_D",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172123344",
+            "submitter_read_group_id": "QCMG:20140124172123344_8013143"
+        },
+        {
+            "file_r1": "899c1cf4660f506f4e6592fe7afcdaea.bam",
+            "file_r2": "899c1cf4660f506f4e6592fe7afcdaea.bam",
+            "insert_size": 318,
+            "platform_unit": "QCMG:20140124172124702_8013143",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_D",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172124702",
+            "submitter_read_group_id": "QCMG:20140124172124702_8013143"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-167",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e75174c1-f053-439d-9885-bf7c679324b6.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e75174c1-f053-439d-9885-bf7c679324b6.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8031544",
+            "matchedNormalSubmitterSampleId": "8031550",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8031544",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0206",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "c4b7390bc69022364c123c9f64b77048.bam",
+            "fileSize": 192362809503,
+            "fileType": "BAM",
+            "fileMd5sum": "c4b7390bc69022364c123c9f64b77048",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "e75174c1-f053-439d-9885-bf7c679324b6",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "c4b7390bc69022364c123c9f64b77048.bam",
+            "file_r2": "c4b7390bc69022364c123c9f64b77048.bam",
+            "insert_size": 291,
+            "platform_unit": "QCMG:20130213041312523_8031544",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4937A2AR25",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130213041312523",
+            "submitter_read_group_id": "QCMG:20130213041312523_8031544"
+        },
+        {
+            "file_r1": "c4b7390bc69022364c123c9f64b77048.bam",
+            "file_r2": "c4b7390bc69022364c123c9f64b77048.bam",
+            "insert_size": 291,
+            "platform_unit": "QCMG:20130213041802348_8031544",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4937A2AR25",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130213041802348",
+            "submitter_read_group_id": "QCMG:20130213041802348_8031544"
+        },
+        {
+            "file_r1": "c4b7390bc69022364c123c9f64b77048.bam",
+            "file_r2": "c4b7390bc69022364c123c9f64b77048.bam",
+            "insert_size": 289,
+            "platform_unit": "QCMG:20130213051438667_8031544",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4937A2AR25",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130213051438667",
+            "submitter_read_group_id": "QCMG:20130213051438667_8031544"
+        },
+        {
+            "file_r1": "c4b7390bc69022364c123c9f64b77048.bam",
+            "file_r2": "c4b7390bc69022364c123c9f64b77048.bam",
+            "insert_size": 289,
+            "platform_unit": "QCMG:2013021305224982_8031544",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4937A2AR25",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013021305224982",
+            "submitter_read_group_id": "QCMG:2013021305224982_8031544"
+        },
+        {
+            "file_r1": "c4b7390bc69022364c123c9f64b77048.bam",
+            "file_r2": "c4b7390bc69022364c123c9f64b77048.bam",
+            "insert_size": 289,
+            "platform_unit": "QCMG:20130213070657346_8031544",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4937A2AR25",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130213070657346",
+            "submitter_read_group_id": "QCMG:20130213070657346_8031544"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-136",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e7d77dd7-54b9-48ce-b3f1-ab14f78178ea.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e7d77dd7-54b9-48ce-b3f1-ab14f78178ea.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8069318",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8069318",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0502",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "cb02c67bf2f2ed0b2b22ab9dd5258553.bam",
+            "fileSize": 71379332014,
+            "fileType": "BAM",
+            "fileMd5sum": "cb02c67bf2f2ed0b2b22ab9dd5258553",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "e7d77dd7-54b9-48ce-b3f1-ab14f78178ea",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "cb02c67bf2f2ed0b2b22ab9dd5258553.bam",
+            "file_r2": "cb02c67bf2f2ed0b2b22ab9dd5258553.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140214232758327_8069318",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232758327",
+            "submitter_read_group_id": "QCMG:20140214232758327_8069318"
+        },
+        {
+            "file_r1": "cb02c67bf2f2ed0b2b22ab9dd5258553.bam",
+            "file_r2": "cb02c67bf2f2ed0b2b22ab9dd5258553.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140214232759664_8069318",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232759664",
+            "submitter_read_group_id": "QCMG:20140214232759664_8069318"
+        },
+        {
+            "file_r1": "cb02c67bf2f2ed0b2b22ab9dd5258553.bam",
+            "file_r2": "cb02c67bf2f2ed0b2b22ab9dd5258553.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140214232811248_8069318",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_V",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232811248",
+            "submitter_read_group_id": "QCMG:20140214232811248_8069318"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-169",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e8a5274c-d8cb-458b-bbbc-8cd9fea982cc.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e8a5274c-d8cb-458b-bbbc-8cd9fea982cc.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8030353",
+            "matchedNormalSubmitterSampleId": "8030360",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8030353",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0063",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "91d08408f6ca92e5d79af5eedb7aa163.bam",
+            "fileSize": 174894974714,
+            "fileType": "BAM",
+            "fileMd5sum": "91d08408f6ca92e5d79af5eedb7aa163",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "e8a5274c-d8cb-458b-bbbc-8cd9fea982cc",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "91d08408f6ca92e5d79af5eedb7aa163.bam",
+            "file_r2": "91d08408f6ca92e5d79af5eedb7aa163.bam",
+            "insert_size": 286,
+            "platform_unit": "QCMG:20130201035707211_8030353",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4927A2AR20",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130201035707211",
+            "submitter_read_group_id": "QCMG:20130201035707211_8030353"
+        },
+        {
+            "file_r1": "91d08408f6ca92e5d79af5eedb7aa163.bam",
+            "file_r2": "91d08408f6ca92e5d79af5eedb7aa163.bam",
+            "insert_size": 287,
+            "platform_unit": "QCMG:20130201052916990_8030353",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4927A2AR20",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130201052916990",
+            "submitter_read_group_id": "QCMG:20130201052916990_8030353"
+        },
+        {
+            "file_r1": "91d08408f6ca92e5d79af5eedb7aa163.bam",
+            "file_r2": "91d08408f6ca92e5d79af5eedb7aa163.bam",
+            "insert_size": 287,
+            "platform_unit": "QCMG:20130201053405804_8030353",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4927A2AR20",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130201053405804",
+            "submitter_read_group_id": "QCMG:20130201053405804_8030353"
+        },
+        {
+            "file_r1": "91d08408f6ca92e5d79af5eedb7aa163.bam",
+            "file_r2": "91d08408f6ca92e5d79af5eedb7aa163.bam",
+            "insert_size": 287,
+            "platform_unit": "QCMG:20130201060510467_8030353",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4927A2AR20",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130201060510467",
+            "submitter_read_group_id": "QCMG:20130201060510467_8030353"
+        },
+        {
+            "file_r1": "91d08408f6ca92e5d79af5eedb7aa163.bam",
+            "file_r2": "91d08408f6ca92e5d79af5eedb7aa163.bam",
+            "insert_size": 287,
+            "platform_unit": "QCMG:20130201060706328_8030353",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA4927A2AR20",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130201060706328",
+            "submitter_read_group_id": "QCMG:20130201060706328_8030353"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-116",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e9bdcd6b-6afc-4147-9b4f-3958792a834a.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/e9bdcd6b-6afc-4147-9b4f-3958792a834a.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8058183",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8058183",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0313",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "b39c29808b3b6bc9c488b28dfa2d97f3.bam",
+            "fileSize": 85381193927,
+            "fileType": "BAM",
+            "fileMd5sum": "b39c29808b3b6bc9c488b28dfa2d97f3",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "e9bdcd6b-6afc-4147-9b4f-3958792a834a",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "b39c29808b3b6bc9c488b28dfa2d97f3.bam",
+            "file_r2": "b39c29808b3b6bc9c488b28dfa2d97f3.bam",
+            "insert_size": 306,
+            "platform_unit": "QCMG:20140214232555783_8058183",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_U",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232555783",
+            "submitter_read_group_id": "QCMG:20140214232555783_8058183"
+        },
+        {
+            "file_r1": "b39c29808b3b6bc9c488b28dfa2d97f3.bam",
+            "file_r2": "b39c29808b3b6bc9c488b28dfa2d97f3.bam",
+            "insert_size": 306,
+            "platform_unit": "QCMG:20140214232556021_8058183",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_U",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232556021",
+            "submitter_read_group_id": "QCMG:20140214232556021_8058183"
+        },
+        {
+            "file_r1": "b39c29808b3b6bc9c488b28dfa2d97f3.bam",
+            "file_r2": "b39c29808b3b6bc9c488b28dfa2d97f3.bam",
+            "insert_size": 306,
+            "platform_unit": "QCMG:20140214232755476_8058183",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_U",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232755476",
+            "submitter_read_group_id": "QCMG:20140214232755476_8058183"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-156",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/ed1cc066-b792-42b9-a32f-351928a924dd.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/ed1cc066-b792-42b9-a32f-351928a924dd.json
@@ -1,0 +1,127 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8067246",
+            "matchedNormalSubmitterSampleId": "8067245",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8067246",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0420",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "fileSize": 190105944541,
+            "fileType": "BAM",
+            "fileMd5sum": "0f85eb2de3c1ffe7bfcf9473bf32fc26",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "ed1cc066-b792-42b9-a32f-351928a924dd",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "file_r2": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140124172254637_8067246",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AA",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172254637",
+            "submitter_read_group_id": "QCMG:20140124172254637_8067246"
+        },
+        {
+            "file_r1": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "file_r2": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140124172255166_8067246",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AA",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172255166",
+            "submitter_read_group_id": "QCMG:20140124172255166_8067246"
+        },
+        {
+            "file_r1": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "file_r2": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140124172256561_8067246",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AA",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172256561",
+            "submitter_read_group_id": "QCMG:20140124172256561_8067246"
+        },
+        {
+            "file_r1": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "file_r2": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140124172257007_8067246",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AA",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172257007",
+            "submitter_read_group_id": "QCMG:20140124172257007_8067246"
+        },
+        {
+            "file_r1": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "file_r2": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140124172258334_8067246",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AA",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172258334",
+            "submitter_read_group_id": "QCMG:20140124172258334_8067246"
+        },
+        {
+            "file_r1": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "file_r2": "0f85eb2de3c1ffe7bfcf9473bf32fc26.bam",
+            "insert_size": 309,
+            "platform_unit": "QCMG:20140124172301886_8067246",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_AA",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172301886",
+            "submitter_read_group_id": "QCMG:20140124172301886_8067246"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-188",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 6
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/ee1169d9-87c7-41be-8bb6-b50d91f603f9.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/ee1169d9-87c7-41be-8bb6-b50d91f603f9.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8069445",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8069445",
+                "specimenType": "Normal - tissue adjacent to primary tumour",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0521",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "f66ee5349e25e8dea48140038098d994.bam",
+            "fileSize": 75951698808,
+            "fileType": "BAM",
+            "fileMd5sum": "f66ee5349e25e8dea48140038098d994",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "ee1169d9-87c7-41be-8bb6-b50d91f603f9",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "f66ee5349e25e8dea48140038098d994.bam",
+            "file_r2": "f66ee5349e25e8dea48140038098d994.bam",
+            "insert_size": 316,
+            "platform_unit": "QCMG:20140214232619867_8069445",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AG",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232619867",
+            "submitter_read_group_id": "QCMG:20140214232619867_8069445"
+        },
+        {
+            "file_r1": "f66ee5349e25e8dea48140038098d994.bam",
+            "file_r2": "f66ee5349e25e8dea48140038098d994.bam",
+            "insert_size": 316,
+            "platform_unit": "QCMG:20140214232620305_8069445",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AG",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232620305",
+            "submitter_read_group_id": "QCMG:20140214232620305_8069445"
+        },
+        {
+            "file_r1": "f66ee5349e25e8dea48140038098d994.bam",
+            "file_r2": "f66ee5349e25e8dea48140038098d994.bam",
+            "insert_size": 314,
+            "platform_unit": "QCMG:20140214232815873_8069445",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140207_AG",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140214232815873",
+            "submitter_read_group_id": "QCMG:20140214232815873_8069445"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-186",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/eef965d6-5574-4cdd-a621-17b2401709ab.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/eef965d6-5574-4cdd-a621-17b2401709ab.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8067245",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8067245",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0420",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "1bc724299e8df753009c32095d31a7d4.bam",
+            "fileSize": 76935228414,
+            "fileType": "BAM",
+            "fileMd5sum": "1bc724299e8df753009c32095d31a7d4",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "eef965d6-5574-4cdd-a621-17b2401709ab",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "1bc724299e8df753009c32095d31a7d4.bam",
+            "file_r2": "1bc724299e8df753009c32095d31a7d4.bam",
+            "insert_size": 316,
+            "platform_unit": "QCMG:20140124172106708_8067245",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172106708",
+            "submitter_read_group_id": "QCMG:20140124172106708_8067245"
+        },
+        {
+            "file_r1": "1bc724299e8df753009c32095d31a7d4.bam",
+            "file_r2": "1bc724299e8df753009c32095d31a7d4.bam",
+            "insert_size": 316,
+            "platform_unit": "QCMG:20140124172107415_8067245",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172107415",
+            "submitter_read_group_id": "QCMG:20140124172107415_8067245"
+        },
+        {
+            "file_r1": "1bc724299e8df753009c32095d31a7d4.bam",
+            "file_r2": "1bc724299e8df753009c32095d31a7d4.bam",
+            "insert_size": 315,
+            "platform_unit": "QCMG:20140124172109777_8067245",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_G",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172109777",
+            "submitter_read_group_id": "QCMG:20140124172109777_8067245"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-182",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/ef6fca61-6114-49c5-a7d4-8b01d120380b.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/ef6fca61-6114-49c5-a7d4-8b01d120380b.json
@@ -1,0 +1,101 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8068563",
+            "matchedNormalSubmitterSampleId": "8053108",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8068563",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0230",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "b1587bcc5fa9c37f5905289b7a7059d1.bam",
+            "fileSize": 128434692184,
+            "fileType": "BAM",
+            "fileMd5sum": "b1587bcc5fa9c37f5905289b7a7059d1",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "ef6fca61-6114-49c5-a7d4-8b01d120380b",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "b1587bcc5fa9c37f5905289b7a7059d1.bam",
+            "file_r2": "b1587bcc5fa9c37f5905289b7a7059d1.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140301133209182_8068563",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140228_C",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140301133209182",
+            "submitter_read_group_id": "QCMG:20140301133209182_8068563"
+        },
+        {
+            "file_r1": "b1587bcc5fa9c37f5905289b7a7059d1.bam",
+            "file_r2": "b1587bcc5fa9c37f5905289b7a7059d1.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140301133210363_8068563",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140228_C",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140301133210363",
+            "submitter_read_group_id": "QCMG:20140301133210363_8068563"
+        },
+        {
+            "file_r1": "b1587bcc5fa9c37f5905289b7a7059d1.bam",
+            "file_r2": "b1587bcc5fa9c37f5905289b7a7059d1.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140301133211252_8068563",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140228_C",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140301133211252",
+            "submitter_read_group_id": "QCMG:20140301133211252_8068563"
+        },
+        {
+            "file_r1": "b1587bcc5fa9c37f5905289b7a7059d1.bam",
+            "file_r2": "b1587bcc5fa9c37f5905289b7a7059d1.bam",
+            "insert_size": 310,
+            "platform_unit": "QCMG:20140301133212388_8068563",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140228_C",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140301133212388",
+            "submitter_read_group_id": "QCMG:20140301133212388_8068563"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-124",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 4
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/f081a8bf-d472-4d09-984d-bc6c24179d4f.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/f081a8bf-d472-4d09-984d-bc6c24179d4f.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8035561",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8035561",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0140",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "d5206818ee30df040229da2f6a8cc53f.bam",
+            "fileSize": 101640817047,
+            "fileType": "BAM",
+            "fileMd5sum": "d5206818ee30df040229da2f6a8cc53f",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "f081a8bf-d472-4d09-984d-bc6c24179d4f",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "d5206818ee30df040229da2f6a8cc53f.bam",
+            "file_r2": "d5206818ee30df040229da2f6a8cc53f.bam",
+            "insert_size": 305,
+            "platform_unit": "QCMG:20130327085705984_8035561",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5302A1AR5",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130327085705984",
+            "submitter_read_group_id": "QCMG:20130327085705984_8035561"
+        },
+        {
+            "file_r1": "d5206818ee30df040229da2f6a8cc53f.bam",
+            "file_r2": "d5206818ee30df040229da2f6a8cc53f.bam",
+            "insert_size": 305,
+            "platform_unit": "QCMG:2013032709074634_8035561",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5302A1AR5",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:2013032709074634",
+            "submitter_read_group_id": "QCMG:2013032709074634_8035561"
+        },
+        {
+            "file_r1": "d5206818ee30df040229da2f6a8cc53f.bam",
+            "file_r2": "d5206818ee30df040229da2f6a8cc53f.bam",
+            "insert_size": 305,
+            "platform_unit": "QCMG:20130327091218399_8035561",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_BIA5302A1AR5",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20130327091218399",
+            "submitter_read_group_id": "QCMG:20130327091218399_8035561"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-135",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/f27252ce-2638-49e7-869e-869954d0bc06.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/f27252ce-2638-49e7-869e-869954d0bc06.json
@@ -1,0 +1,101 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8068548",
+            "matchedNormalSubmitterSampleId": "8068549",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8068548",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0124",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "a7eae8d9a0f4e415c3a0600bffaa6cd2.bam",
+            "fileSize": 136919018089,
+            "fileType": "BAM",
+            "fileMd5sum": "a7eae8d9a0f4e415c3a0600bffaa6cd2",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "f27252ce-2638-49e7-869e-869954d0bc06",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "a7eae8d9a0f4e415c3a0600bffaa6cd2.bam",
+            "file_r2": "a7eae8d9a0f4e415c3a0600bffaa6cd2.bam",
+            "insert_size": 308,
+            "platform_unit": "QCMG:20140301133205485_8068548",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140228_B",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140301133205485",
+            "submitter_read_group_id": "QCMG:20140301133205485_8068548"
+        },
+        {
+            "file_r1": "a7eae8d9a0f4e415c3a0600bffaa6cd2.bam",
+            "file_r2": "a7eae8d9a0f4e415c3a0600bffaa6cd2.bam",
+            "insert_size": 308,
+            "platform_unit": "QCMG:20140301133206577_8068548",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140228_B",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140301133206577",
+            "submitter_read_group_id": "QCMG:20140301133206577_8068548"
+        },
+        {
+            "file_r1": "a7eae8d9a0f4e415c3a0600bffaa6cd2.bam",
+            "file_r2": "a7eae8d9a0f4e415c3a0600bffaa6cd2.bam",
+            "insert_size": 308,
+            "platform_unit": "QCMG:20140301133207327_8068548",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140228_B",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140301133207327",
+            "submitter_read_group_id": "QCMG:20140301133207327_8068548"
+        },
+        {
+            "file_r1": "a7eae8d9a0f4e415c3a0600bffaa6cd2.bam",
+            "file_r2": "a7eae8d9a0f4e415c3a0600bffaa6cd2.bam",
+            "insert_size": 308,
+            "platform_unit": "QCMG:20140301133208250_8068548",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140228_B",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140301133208250",
+            "submitter_read_group_id": "QCMG:20140301133208250_8068548"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-180",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 4
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/f2bf2c87-4e38-4256-886a-0af11568e002.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/f2bf2c87-4e38-4256-886a-0af11568e002.json
@@ -1,0 +1,88 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8058186",
+            "matchedNormalSubmitterSampleId": null,
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8058186",
+                "specimenType": "Normal",
+                "tumourNormalDesignation": "Normal",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0303",
+                "gender": "Female"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "8842de91d4f85dd637e742f75c8a7f1b.bam",
+            "fileSize": 69287610892,
+            "fileType": "BAM",
+            "fileMd5sum": "8842de91d4f85dd637e742f75c8a7f1b",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "f2bf2c87-4e38-4256-886a-0af11568e002",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "8842de91d4f85dd637e742f75c8a7f1b.bam",
+            "file_r2": "8842de91d4f85dd637e742f75c8a7f1b.bam",
+            "insert_size": 379,
+            "platform_unit": "QCMG:20131009014749510_8058186",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131009014749510",
+            "submitter_read_group_id": "QCMG:20131009014749510_8058186"
+        },
+        {
+            "file_r1": "8842de91d4f85dd637e742f75c8a7f1b.bam",
+            "file_r2": "8842de91d4f85dd637e742f75c8a7f1b.bam",
+            "insert_size": 379,
+            "platform_unit": "QCMG:20131009015531579_8058186",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131009015531579",
+            "submitter_read_group_id": "QCMG:20131009015531579_8058186"
+        },
+        {
+            "file_r1": "8842de91d4f85dd637e742f75c8a7f1b.bam",
+            "file_r2": "8842de91d4f85dd637e742f75c8a7f1b.bam",
+            "insert_size": 379,
+            "platform_unit": "QCMG:20131009025415432_8058186",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130830_N",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131009025415432",
+            "submitter_read_group_id": "QCMG:20131009025415432_8058186"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-187",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 3
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/f5c0bc30-7591-4aa6-a8f7-74eee051ef9c.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/f5c0bc30-7591-4aa6-a8f7-74eee051ef9c.json
@@ -1,0 +1,114 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8066037",
+            "matchedNormalSubmitterSampleId": "8044061",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8066037",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0150",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "75f0cbcf4eec003e851ac6fae6315471.bam",
+            "fileSize": 116803634401,
+            "fileType": "BAM",
+            "fileMd5sum": "75f0cbcf4eec003e851ac6fae6315471",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "f5c0bc30-7591-4aa6-a8f7-74eee051ef9c",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "75f0cbcf4eec003e851ac6fae6315471.bam",
+            "file_r2": "75f0cbcf4eec003e851ac6fae6315471.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:20131130025928876_8066037",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131130025928876",
+            "submitter_read_group_id": "QCMG:20131130025928876_8066037"
+        },
+        {
+            "file_r1": "75f0cbcf4eec003e851ac6fae6315471.bam",
+            "file_r2": "75f0cbcf4eec003e851ac6fae6315471.bam",
+            "insert_size": 377,
+            "platform_unit": "QCMG:20131130030213309_8066037",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131130030213309",
+            "submitter_read_group_id": "QCMG:20131130030213309_8066037"
+        },
+        {
+            "file_r1": "75f0cbcf4eec003e851ac6fae6315471.bam",
+            "file_r2": "75f0cbcf4eec003e851ac6fae6315471.bam",
+            "insert_size": 378,
+            "platform_unit": "QCMG:20131130034747776_8066037",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131130034747776",
+            "submitter_read_group_id": "QCMG:20131130034747776_8066037"
+        },
+        {
+            "file_r1": "75f0cbcf4eec003e851ac6fae6315471.bam",
+            "file_r2": "75f0cbcf4eec003e851ac6fae6315471.bam",
+            "insert_size": 377,
+            "platform_unit": "QCMG:20131130040353864_8066037",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131130040353864",
+            "submitter_read_group_id": "QCMG:20131130040353864_8066037"
+        },
+        {
+            "file_r1": "75f0cbcf4eec003e851ac6fae6315471.bam",
+            "file_r2": "75f0cbcf4eec003e851ac6fae6315471.bam",
+            "insert_size": 376,
+            "platform_unit": "QCMG:20131130061930581_8066037",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_20130906_E",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20131130061930581",
+            "submitter_read_group_id": "QCMG:20131130061930581_8066037"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-166",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 5
+}

--- a/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/f71bb187-8887-48e8-be6e-cd74a079bf1e.json
+++ b/icgc_song_payloads/APGI-AU/WGS/batch3-pcawg/f71bb187-8887-48e8-be6e-cd74a079bf1e.json
@@ -1,0 +1,127 @@
+{
+    "studyId": "APGI-AU",
+    "analysisType": {
+        "name": "sequencing_experiment"
+    },
+    "samples": [
+        {
+            "submitterSampleId": "8067175",
+            "matchedNormalSubmitterSampleId": "8067176",
+            "sampleType": "Total DNA",
+            "specimen": {
+                "submitterSpecimenId": "8067175",
+                "specimenType": "Primary tumour",
+                "tumourNormalDesignation": "Tumour",
+                "specimenTissueSource": "Solid tissue"
+            },
+            "donor": {
+                "submitterDonorId": "ICGC_0391",
+                "gender": "Male"
+            }
+        }
+    ],
+    "files": [
+        {
+            "dataType": "Submitted Reads",
+            "fileName": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "fileSize": 184011950973,
+            "fileType": "BAM",
+            "fileMd5sum": "e6cf7695979d10c6c78a34e47a89687a",
+            "fileAccess": "controlled",
+            "info": {
+                "legacyAnalysisId": "f71bb187-8887-48e8-be6e-cd74a079bf1e",
+                "data_category": "Sequencing Reads",
+                "origin": "ICGC-25K"
+            }
+        }
+    ],
+    "read_groups": [
+        {
+            "file_r1": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "file_r2": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140124172151085_8067175",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172151085",
+            "submitter_read_group_id": "QCMG:20140124172151085_8067175"
+        },
+        {
+            "file_r1": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "file_r2": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140124172152358_8067175",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172152358",
+            "submitter_read_group_id": "QCMG:20140124172152358_8067175"
+        },
+        {
+            "file_r1": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "file_r2": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140124172153841_8067175",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172153841",
+            "submitter_read_group_id": "QCMG:20140124172153841_8067175"
+        },
+        {
+            "file_r1": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "file_r2": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140124172204624_8067175",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172204624",
+            "submitter_read_group_id": "QCMG:20140124172204624_8067175"
+        },
+        {
+            "file_r1": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "file_r2": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140124172205004_8067175",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172205004",
+            "submitter_read_group_id": "QCMG:20140124172205004_8067175"
+        },
+        {
+            "file_r1": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "file_r2": "e6cf7695979d10c6c78a34e47a89687a.bam",
+            "insert_size": 312,
+            "platform_unit": "QCMG:20140124172206572_8067175",
+            "is_paired_end": true,
+            "library_name": "WGS:QCMG:Library_EXT20140107_K",
+            "read_length_r1": null,
+            "read_length_r2": null,
+            "sample_barcode": null,
+            "read_group_id_in_bam": "QCMG:20140124172206572",
+            "submitter_read_group_id": "QCMG:20140124172206572_8067175"
+        }
+    ],
+    "experiment": {
+        "submitter_sequencing_experiment_id": "EXP-175",
+        "experimental_strategy": "WGS",
+        "sequencing_center": "QCMG",
+        "platform": "ILLUMINA",
+        "platform_model": "Illumina HiSeq 2000",
+        "sequencing_date": null
+    },
+    "read_group_count": 6
+}


### PR DESCRIPTION
…A-AU ICGC25K project to be imported to ARGO's APGI-AU program
Related to https://github.com/icgc-argo/workflow-roadmap/issues/344

A total of 45 ICGC25K donors will be imported to ARGO as per Amber's request for the APGI-AU program